### PR TITLE
Benchmark dot operator 

### DIFF
--- a/benchmark/python/sparse_op.py
+++ b/benchmark/python/sparse_op.py
@@ -83,11 +83,13 @@ def test_dot_synthetic():
                 result.wait_to_read()
             end = time.time()
             duration = end - start
-            durations.append(duration)
+            durations.append(duration / num_iter)
         ratio = durations[1] / durations[0]
-        print("%0.1f\t%s\t%d\t%d\t%d\t%0.2f" % (density * 100, str(ctx), n, m, k, ratio))
+        fmt = "%0.1f\t%s\t%d\t%d\t%d\t%0.6f\t%0.5f\t%0.2f"
+        print(fmt % (density * 100, str(ctx), n, m, k, durations[1], durations[0], ratio))
 
-    print('nnz(%)\tcontext\tn\tm\tk\tt_sparse/t_dense')
+    print('nnz(%)\tcontext\tn\tm\tk\tt_sparse\tt_dense\tt_sparse/t_dense')
+    # TODO(haibin) make these runtime options
     m = 512
     k = 50000
     n = 50

--- a/benchmark/python/sparse_op.py
+++ b/benchmark/python/sparse_op.py
@@ -8,25 +8,33 @@ import pickle as pickle
 import time
 import sys
 
-def test_dot_real(dataset):
+def get_avazu(data_dir):
+    if not os.path.isdir(data_dir):
+        os.system("mkdir " + data_dir)
+    os.chdir(data_dir)
+    if (not os.path.exists('avazu-app.t')):
+        import urllib, zipfile
+        zippath = os.path.join(data_dir, "avazu-app.t.bz2")
+        url = "https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/avazu-app.t.bz2"
+        urllib.urlretrieve(url, zippath)
+        # decompress
+        os.system("bzip2 -d avazu-app.t.bz2")
+    os.chdir("..")
+
+def test_dot_real():
     def get_iter(path, data_shape, batch_size):
         data_train = mx.io.LibSVMIter(data_libsvm=path,
                                       data_shape=data_shape,
                                       batch_size=batch_size)
         data_iter = iter(data_train)
         return data_iter
-    # TODO(haibin) add script downloading dataset
-    batch_size = 512
-    if dataset == 'train':
-        size = 2858375979 >> 20
-        path = "/home/ubuntu/svm/avazu-app"
-    elif dataset == 'test':
-        size = 336490781 >> 20
-        path = "/home/ubuntu/svm/avazu-app.t"
-    else:
-        raise Exception('unknown dataset')
+    data_dir = os.path.join(os.getcwd(), 'data')
+    get_avazu(data_dir)
+    path = os.path.join(data_dir, 'avazu-app.t')
+    size = 336490781 >> 20
 
     # model
+    batch_size = 512
     feature_dim = 1000000
     data_shape = (feature_dim, )
     train_iter = get_iter(path, data_shape, batch_size)
@@ -91,5 +99,5 @@ def test_dot_synthetic():
             bench_dot(m, k, n, den, ctx)
 
 if __name__ == "__main__":
-    #test_dot_real('test')
+    test_dot_real()
     test_dot_synthetic()

--- a/benchmark/python/sparse_op.py
+++ b/benchmark/python/sparse_op.py
@@ -89,7 +89,7 @@ def test_dot_synthetic():
             duration = end - start
             durations.append(duration / num_iter)
         ratio = durations[1] / durations[0]
-        fmt = "%0.1f\t%s\t%d\t%d\t%d\t%0.6f\t%0.5f\t%0.2f"
+        fmt = "%0.1f\t\t%s\t%d\t%d\t%d\t%0.6f\t%0.5f\t%0.2f"
         print(fmt % (density * 100, str(ctx), n, m, k, durations[1], durations[0], ratio))
 
     print("A = sparse NDArray of shape(m, k)")
@@ -97,14 +97,15 @@ def test_dot_synthetic():
     print('density(%)\tcontext\tn\tm\tk\tt_sparse\tt_dense\tt_sparse/t_dense')
     # TODO(haibin) make these runtime options
     m = 512
-    k = 50000
-    n = 50
+    k = [50000, 500000]
+    n = [50, 500]
     density = [0.1, 0.05, 0.01, 0.005, 0.001]
     # contexts = [mx.cpu(), mx.gpu(0)]
     contexts = [mx.cpu()]
-    for ctx in contexts:
-        for den in density:
-            bench_dot(m, k, n, den, ctx)
+    for i in range(2):
+        for ctx in contexts:
+            for den in density:
+                bench_dot(m, k[i], n[i], den, ctx)
 
 if __name__ == "__main__":
     test_dot_real()

--- a/benchmark/python/sparse_op.py
+++ b/benchmark/python/sparse_op.py
@@ -59,6 +59,10 @@ def test_dot_real():
     print(size / duration, duration, num_batch, num_batch / duration)
 
 def test_dot_synthetic():
+    """benchmark mx.nd.dot(sparse_ndarray, dense_ndarray) with given density.
+    `t_sparse` is the time cost of dot(csr, dns), while `t_dense` is the time cost
+    of dot(dns, dns), with the same matrix except that it is in default storage type.
+    """
     def bench_dot(m, k, n, density, ctx):
         set_default_context(ctx)
         weight = mx.nd.random_uniform(low=0, high=1, shape=(k, n))
@@ -88,7 +92,9 @@ def test_dot_synthetic():
         fmt = "%0.1f\t%s\t%d\t%d\t%d\t%0.6f\t%0.5f\t%0.2f"
         print(fmt % (density * 100, str(ctx), n, m, k, durations[1], durations[0], ratio))
 
-    print('nnz(%)\tcontext\tn\tm\tk\tt_sparse\tt_dense\tt_sparse/t_dense')
+    print("A = sparse NDArray of shape(m, k)")
+    print("B = dense NDArray of shape(k, n)")
+    print('density(%)\tcontext\tn\tm\tk\tt_sparse\tt_dense\tt_sparse/t_dense')
     # TODO(haibin) make these runtime options
     m = 512
     k = 50000

--- a/include/mxnet/io.h
+++ b/include/mxnet/io.h
@@ -44,6 +44,19 @@ class IIterator : public dmlc::DataIter<DType> {
   }
 };  // class IIterator
 
+/*!
+ * \brief iterator type
+ * \param DType data type
+ */
+template<typename DType>
+class SparseIIterator : public IIterator<DType> {
+ public:
+  /*! \brief storage type of the data or label */
+  virtual const NDArrayStorageType GetStorageType(bool is_data) const = 0;
+  /*! \brief shape of the data or label */
+  virtual const TShape GetShape(bool is_data) const = 0;
+};  // class SparseIIterator
+
 /*! \brief a single data instance */
 struct DataInst {
   /*! \brief unique id for instance */

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -306,6 +306,20 @@ class NDArray {
     CHECK(!is_none());
     return ptr_->aux_types[i];
   }
+  /*!
+   * \return the number of aux data used for given storage type
+   */
+  static size_t NumAuxData(NDArrayStorageType stype) {
+    size_t num = 0;
+    switch (stype) {
+      case kDefaultStorage: num = 0; break;
+      case kCSRStorage: num = 2; break;
+      case kRowSparseStorage: num = 1; break;
+       default: LOG(FATAL) << "Unknown storage type" << stype; break;
+    }
+    return num;
+  }
+
   inline NDArrayStorageType storage_type() const {
     if (is_none()) return kUndefinedStorage;
     return ptr_->storage_type;

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -13,6 +13,7 @@ from .base import DataIterHandle, NDArrayHandle
 from .base import mx_real_t
 from .base import check_call, build_param_doc as _build_param_doc
 from .ndarray import NDArray
+from .sparse_ndarray import _ndarray_cls
 from .ndarray import array
 from .ndarray import concatenate
 
@@ -752,12 +753,12 @@ class MXDataIter(DataIter):
     def getdata(self):
         hdl = NDArrayHandle()
         check_call(_LIB.MXDataIterGetData(self.handle, ctypes.byref(hdl)))
-        return NDArray(hdl, False)
+        return _ndarray_cls(hdl, False)
 
     def getlabel(self):
         hdl = NDArrayHandle()
         check_call(_LIB.MXDataIterGetLabel(self.handle, ctypes.byref(hdl)))
-        return NDArray(hdl, False)
+        return _ndarray_cls(hdl, False)
 
     def getindex(self):
         index_size = ctypes.c_uint64(0)

--- a/python/mxnet/sparse_ndarray.py
+++ b/python/mxnet/sparse_ndarray.py
@@ -600,11 +600,13 @@ def zeros(storage_type, shape, ctx=None, dtype=None, aux_types=None):
     out = SparseNDArray(_new_alloc_handle(storage_type, shape, ctx, True, dtype, aux_types))
     return _internal._zeros(shape=shape, ctx=ctx, dtype=dtype, out=out)
 
-def _ndarray_cls(handle):
+def _ndarray_cls(handle, writable=True):
     stype = _storage_type(handle)
     # TODO(haibin) in the long run, we want to have CSRNDArray and RowSparseNDArray which
     # inherit from SparseNDArray
-    return NDArray(handle) if stype == 'default_storage' else SparseNDArray(handle)
+    if stype == 'default_storage':
+        return NDArray(handle, writable)
+    return SparseNDArray(handle, writable)
 
 # pylint: enable=too-many-locals, invalid-name
 def _init_ndarray_module(ndarray_class, root_namespace):

--- a/src/io/iter_batchloader.h
+++ b/src/io/iter_batchloader.h
@@ -23,7 +23,7 @@ namespace io {
 class BatchLoader : public IIterator<TBlobBatch> {
  public:
   explicit BatchLoader(IIterator<DataInst> *base):
-      base_(base), head_(1), num_overflow_(0) {
+    head(1), num_overflow(0), base_(base) {
   }
 
   virtual ~BatchLoader(void) {
@@ -33,119 +33,122 @@ class BatchLoader : public IIterator<TBlobBatch> {
   inline void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
     std::vector<std::pair<std::string, std::string> > kwargs_left;
     // init batch param, it could have similar param with
-    kwargs_left = param_.InitAllowUnknown(kwargs);
-    // Init space for out_
-    out_.inst_index = new unsigned[param_.batch_size];
-    out_.batch_size = param_.batch_size;
-    out_.data.clear();
+    kwargs_left = param.InitAllowUnknown(kwargs);
+    // Init space for out
+    out.inst_index = new unsigned[param.batch_size];
+    out.batch_size = param.batch_size;
+    out.data.clear();
     // init base iterator
     base_->Init(kwargs);
   }
 
   virtual void BeforeFirst(void) {
-    if (param_.round_batch == 0 || num_overflow_ == 0) {
+    if (param.round_batch == 0 || num_overflow == 0) {
       // otherise, we already called before first
       base_->BeforeFirst();
     } else {
-      num_overflow_ = 0;
+      num_overflow = 0;
     }
-    head_ = 1;
+    head = 1;
   }
+
   virtual bool Next(void) {
-    out_.num_batch_padd = 0;
-    out_.batch_size = param_.batch_size;
-    this->head_ = 0;
+    out.num_batch_padd = 0;
+    out.batch_size = param.batch_size;
+    this->head = 0;
 
     // if overflow from previous round, directly return false, until before first is called
-    if (num_overflow_ != 0) return false;
+    if (num_overflow != 0) return false;
     index_t top = 0;
 
     while (base_->Next()) {
       const DataInst& d = base_->Value();
-      out_.inst_index[top] = d.index;
-      if (data_.size() == 0) {
+      out.inst_index[top] = d.index;
+      if (data.size() == 0) {
         this->InitData(d);
       }
       for (size_t i = 0; i < d.data.size(); ++i) {
         CHECK_EQ(unit_size_[i], d.data[i].Size());
-        MSHADOW_TYPE_SWITCH(data_[i].type_flag_, DType, {
+        MSHADOW_TYPE_SWITCH(data[i].type_flag_, DType, {
             mshadow::Copy(
-              data_[i].get<cpu, 1, DType>().Slice(top * unit_size_[i],
+              data[i].get<cpu, 1, DType>().Slice(top * unit_size_[i],
                                                   (top + 1) * unit_size_[i]),
               d.data[i].get_with_shape<cpu, 1, DType>(mshadow::Shape1(unit_size_[i])));
           });
       }
-      if (++top >= param_.batch_size) {
+      if (++top >= param.batch_size) {
         return true;
       }
     }
     if (top != 0) {
-      if (param_.round_batch != 0) {
-        num_overflow_ = 0;
+      if (param.round_batch != 0) {
+        num_overflow = 0;
         base_->BeforeFirst();
-        for (; top < param_.batch_size; ++top, ++num_overflow_) {
+        for (; top < param.batch_size; ++top, ++num_overflow) {
           CHECK(base_->Next()) << "number of input must be bigger than batch size";
           const DataInst& d = base_->Value();
-          out_.inst_index[top] = d.index;
+          out.inst_index[top] = d.index;
           // copy data
           for (size_t i = 0; i < d.data.size(); ++i) {
             CHECK_EQ(unit_size_[i], d.data[i].Size());
-            MSHADOW_TYPE_SWITCH(data_[i].type_flag_, DType, {
+            MSHADOW_TYPE_SWITCH(data[i].type_flag_, DType, {
                 mshadow::Copy(
-                  data_[i].get<cpu, 1, DType>().Slice(top * unit_size_[i],
+                  data[i].get<cpu, 1, DType>().Slice(top * unit_size_[i],
                                                       (top + 1) * unit_size_[i]),
                   d.data[i].get_with_shape<cpu, 1, DType>(mshadow::Shape1(unit_size_[i])));
               });
           }
         }
-        out_.num_batch_padd = num_overflow_;
+        out.num_batch_padd = num_overflow;
       } else {
-        out_.num_batch_padd = param_.batch_size - top;
+        out.num_batch_padd = param.batch_size - top;
       }
       return true;
     }
     return false;
   }
   virtual const TBlobBatch &Value(void) const {
-    return out_;
+    return out;
   }
 
- private:
+ protected:
   /*! \brief batch parameters */
-  BatchParam param_;
+  BatchParam param;
   /*! \brief output data */
-  TBlobBatch out_;
+  TBlobBatch out;
+  /*! \brief on first */
+  int head;
+  /*! \brief number of overflow instances that readed in round_batch mode */
+  int num_overflow;
+  /*! \brief tensor to hold data */
+  std::vector<TBlobContainer> data;
+
+ private:
   /*! \brief base iterator */
   IIterator<DataInst> *base_;
-  /*! \brief on first */
-  int head_;
-  /*! \brief number of overflow instances that readed in round_batch mode */
-  int num_overflow_;
   /*! \brief data shape */
   std::vector<TShape> shape_;
   /*! \brief unit size */
   std::vector<size_t> unit_size_;
-  /*! \brief tensor to hold data */
-  std::vector<TBlobContainer> data_;
   // initialize the data holder by using from the first batch.
   inline void InitData(const DataInst& first_batch) {
     shape_.resize(first_batch.data.size());
-    data_.resize(first_batch.data.size());
+    data.resize(first_batch.data.size());
     unit_size_.resize(first_batch.data.size());
     for (size_t i = 0; i < first_batch.data.size(); ++i) {
       TShape src_shape = first_batch.data[i].shape_;
       int src_type_flag = first_batch.data[i].type_flag_;
       // init object attributes
       std::vector<index_t> shape_vec;
-      shape_vec.push_back(param_.batch_size);
+      shape_vec.push_back(param.batch_size);
       for (index_t dim = 0; dim < src_shape.ndim(); ++dim) {
         shape_vec.push_back(src_shape[dim]);
       }
       TShape dst_shape(shape_vec.begin(), shape_vec.end());
       shape_[i] = dst_shape;
-      data_[i].resize(mshadow::Shape1(dst_shape.Size()), src_type_flag);
+      data[i].resize(mshadow::Shape1(dst_shape.Size()), src_type_flag);
       unit_size_[i] = src_shape.Size();
-      out_.data.push_back(TBlob(data_[i].dptr_, dst_shape, cpu::kDevMask, src_type_flag));
+      out.data.push_back(TBlob(data[i].dptr_, dst_shape, cpu::kDevMask, src_type_flag));
     }
   }
 };  // class BatchLoader

--- a/src/io/iter_libsvm.cc
+++ b/src/io/iter_libsvm.cc
@@ -1,0 +1,259 @@
+/*!
+ *  Copyright (c) 2015 by Contributors
+ * \file iter_libsvm.cc
+ * \brief define a LibSVM Reader to read in arrays
+ */
+#include <mxnet/io.h>
+#include <dmlc/base.h>
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <dmlc/data.h>
+#include "./iter_sparse_prefetcher.h"
+#include "./iter_sparse_batchloader.h"
+
+namespace mxnet {
+namespace io {
+// LibSVM parameters
+struct LibSVMIterParam : public dmlc::Parameter<LibSVMIterParam> {
+  /*! \brief path to data libsvm file */
+  std::string data_libsvm;
+  /*! \brief data shape */
+  TShape data_shape;
+  /*! \brief path to label libsvm file */
+  std::string label_libsvm;
+  /*! \brief label shape */
+  TShape label_shape;
+  // declare parameters
+  DMLC_DECLARE_PARAMETER(LibSVMIterParam) {
+    DMLC_DECLARE_FIELD(data_libsvm)
+        .describe("The input LibSVM file or a directory path.");
+    DMLC_DECLARE_FIELD(data_shape)
+        .describe("The shape of one example.");
+    DMLC_DECLARE_FIELD(label_libsvm).set_default("NULL")
+        .describe("The input LibSVM file or a directory path. "
+                  "If NULL, all labels will be read from ``data_libsvm``.");
+    index_t shape1[] = {1};
+    DMLC_DECLARE_FIELD(label_shape).set_default(TShape(shape1, shape1 + 1))
+        .describe("The shape of one label.");
+  }
+};
+
+class LibSVMIter: public SparseIIterator<DataInst> {
+ public:
+  LibSVMIter() {}
+  virtual ~LibSVMIter() {}
+
+  // intialize iterator loads data in
+  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+    param_.InitAllowUnknown(kwargs);
+    data_parser_.reset(dmlc::Parser<uint32_t>::Create(param_.data_libsvm.c_str(),
+                                                      0, 1, "libsvm"));
+    CHECK_EQ(param_.data_shape.ndim(), 1) << "dimension of data_shape is expected to be 1";
+    if (param_.label_libsvm != "NULL") {
+      label_parser_.reset(dmlc::Parser<uint32_t>::Create(param_.label_libsvm.c_str(),
+                                                         0, 1, "libsvm"));
+      CHECK_GT(param_.label_shape.Size(), 1)
+        << "label_shape is not expected to be (1,) when param_.label_libsvm is set.";
+    } else {
+      CHECK_EQ(param_.label_shape.Size(), 1)
+        << "label_shape is expected to be (1,) when param_.label_libsvm is NULL";
+    }
+    // both data and label are of CSRStorage in libsvm format
+    if (param_.label_shape.Size() > 1) {
+      out_.data.resize(6);
+    } else {
+      // only data is of CSRStorage in libsvm format.
+      out_.data.resize(4);
+    }
+  }
+
+  virtual void BeforeFirst() {
+    data_parser_->BeforeFirst();
+    if (label_parser_.get() != nullptr) {
+      label_parser_->BeforeFirst();
+    }
+    data_ptr_ = label_ptr_ = 0;
+    data_size_ = label_size_ = 0;
+    inst_counter_ = 0;
+    end_ = false;
+  }
+
+  virtual bool Next() {
+    if (end_) return false;
+    while (data_ptr_ >= data_size_) {
+      if (!data_parser_->Next()) {
+        end_ = true; return false;
+      }
+      data_ptr_ = 0;
+      data_size_ = data_parser_->Value().size;
+    }
+    out_.index = inst_counter_++;
+    CHECK_LT(data_ptr_, data_size_);
+    const auto data_row = data_parser_->Value()[data_ptr_++];
+    // data, indices and indptr
+    out_.data[0] = AsDataBlob(data_row);
+    out_.data[1] = AsIdxBlob(data_row);
+    out_.data[2] = AsIndPtrPlaceholder(data_row);
+
+    if (label_parser_.get() != nullptr) {
+      while (label_ptr_ >= label_size_) {
+        CHECK(label_parser_->Next())
+            << "Data LibSVM's row is smaller than the number of rows in label_libsvm";
+        label_ptr_ = 0;
+        label_size_ = label_parser_->Value().size;
+      }
+      CHECK_LT(label_ptr_, label_size_);
+      const auto label_row = label_parser_->Value()[label_ptr_++];
+      // data, indices and indptr
+      out_.data[3] = AsDataBlob(label_row);
+      out_.data[4] = AsIdxBlob(label_row);
+      out_.data[5] = AsIndPtrPlaceholder(label_row);
+    } else {
+      out_.data[3] = AsScalarLabelBlob(data_row);
+    }
+    return true;
+  }
+
+  virtual const DataInst &Value(void) const {
+    return out_;
+  }
+
+  virtual const NDArrayStorageType GetStorageType(bool is_data) const {
+    if (is_data) return kCSRStorage;
+    return param_.label_shape.Size() > 1 ? kCSRStorage : kDefaultStorage;
+  }
+
+  virtual const TShape GetShape(bool is_data) const {
+    if (is_data) return param_.data_shape;
+    return param_.label_shape;
+  }
+
+ private:
+
+  inline TBlob AsDataBlob(const dmlc::Row<uint32_t>& row) {
+    const real_t* ptr = row.value;
+    TShape shape(mshadow::Shape1(row.length));
+    return TBlob((real_t*) ptr, shape, cpu::kDevMask);
+  }
+
+  inline TBlob AsIdxBlob(const dmlc::Row<uint32_t>& row) {
+    const uint32_t* ptr = row.index;
+    TShape shape(mshadow::Shape1(row.length));
+    return TBlob((int32_t*) ptr, shape, cpu::kDevMask, CSR_IDX_DTYPE);
+  }
+
+  inline TBlob AsIndPtrPlaceholder(const dmlc::Row<uint32_t>& row) {
+    return TBlob(nullptr, mshadow::Shape1(0), cpu::kDevMask, CSR_IND_PTR_TYPE);
+  }
+
+  inline TBlob AsScalarLabelBlob(const dmlc::Row<uint32_t>& row) {
+    const real_t* ptr = row.label;
+    return TBlob((real_t*) ptr, mshadow::Shape1(1), cpu::kDevMask);
+  }
+
+  LibSVMIterParam param_;
+  // output instance
+  DataInst out_;
+  // internal instance counter
+  unsigned inst_counter_{0};
+  // at end
+  bool end_{false};
+  // label parser
+  size_t label_ptr_{0}, label_size_{0};
+  size_t data_ptr_{0}, data_size_{0};
+  std::unique_ptr<dmlc::Parser<uint32_t> > label_parser_;
+  std::unique_ptr<dmlc::Parser<uint32_t> > data_parser_;
+};
+
+
+DMLC_REGISTER_PARAMETER(LibSVMIterParam);
+
+MXNET_REGISTER_IO_ITER(LibSVMIter)
+.describe(R"code(Returns the LibSVM file iterator. This iterator is experimental and
+should be used with care.
+
+The input data is similar to libsvm file format, except that the indices are expected to be
+zero-based instead of one-based. Details of the libsvm format are available at
+`https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/`
+
+In this function, the `data_shape` parameter is used to set the shape of each line of the data.
+The dimension of both `data_shape` and `label_shape` are expected to be 1.
+
+When `label_libsvm` is set to ``NULL``, both data and label are read from the same file specified
+by `data_libsvm`. Otherwise, data is read from `data_libsvm` and label from `label_libsvm`,
+in this case, if `data_libsvm` contains label, it will ignored.
+
+The `LibSVMIter` only support `round_batch` parameter set to ``True`` for now. So, if `batch_size`
+is 3 and there are 4 total rows in libsvm file, 2 more examples
+are consumed at the first round. If `reset` function is called after first round,
+the call is ignored and remaining examples are returned in the second round.
+
+If ``data_libsvm = 'data/'`` is set, then all the files in this directory will be read.
+
+Examples::
+
+  // Contents of libsvm file ``data.t``.
+  1.0 0:0.5 2:1.2
+  -2.0
+  -3.0 0:0.6 1:2.4 2:1.2
+  4 2:-1.2
+
+  // Creates a `LibSVMIter` with `batch_size`=3.
+  LibSVMIter = mx.io.LibSVMIter(data_libsvm = 'data.t', data_shape = (3,),
+  batch_size = 3)
+
+  // The first batch (data and label)
+  [[ 0.5         0.          1.2 ]
+   [ 0.          0.          0.  ]
+   [ 0.6         2.4         1.2 ]]
+
+  [ 1. -2. -3.]
+
+  // The second batch (data and label)
+  [[ 0.          0.         -1.2 ]
+   [ 0.5         0.          1.2 ]
+   [ 0.          0.          0. ]]
+
+  [ 4.  1. -2.]
+
+  // Contents of libsvm file ``label.t``
+  1.0
+  -2.0 0:0.125
+  -3.0 2:1.2
+  4 1:1.0 2:-1.2
+
+  // Creates a `LibSVMIter` with specified label file
+  LibSVMIter = mx.io.LibSVMIter(data_libsvm = 'data.t', data_shape = (3,),
+  label_libsvm = 'label.t', label_shape = (3,), batch_size = 3)
+
+  // Two batches of data read from the above iterator are as follows(data and label):
+  // The first batch
+  [[ 0.5         0.          1.2       ]
+   [ 0.          0.          0.        ]
+   [ 0.6         2.4         1.2      ]]
+
+  [[ 0.          0.          0.        ]
+   [ 0.125       0.          0.        ]
+   [ 0.          0.          1.2      ]]
+
+  // The second batch
+  [[ 0.          0.         -1.2       ]
+   [ 0.5         0.          1.2       ]
+   [ 0.          0.          0.        ]]
+
+  [[ 0.          1.         -1.2       ]
+   [ 0.          0.          0.        ]
+   [ 0.125       0.          0.        ]]
+
+)code" ADD_FILELINE)
+.add_arguments(LibSVMIterParam::__FIELDS__())
+.add_arguments(BatchParam::__FIELDS__())
+.add_arguments(PrefetcherParam::__FIELDS__())
+.set_body([]() {
+    return new SparsePrefetcherIter(
+        new SparseBatchLoader(
+            new LibSVMIter()));
+  });
+
+}  // namespace io
+}  // namespace mxnet

--- a/src/io/iter_prefetcher.h
+++ b/src/io/iter_prefetcher.h
@@ -28,8 +28,7 @@ namespace io {
 class PrefetcherIter : public IIterator<DataBatch> {
  public:
   explicit PrefetcherIter(IIterator<TBlobBatch>* base)
-      : loader_(base), out_(nullptr) {
-  }
+      : loader_(base), out_(nullptr) {}
 
   ~PrefetcherIter() {
     while (recycle_queue_.size() != 0) {
@@ -38,10 +37,10 @@ class PrefetcherIter : public IIterator<DataBatch> {
       delete batch;
     }
     delete out_;
-    iter_.Destroy();
+    iter.Destroy();
   }
 
-  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+  void InitParams(const std::vector<std::pair<std::string, std::string> >& kwargs) {
     std::vector<std::pair<std::string, std::string> > kwargs_left;
     // init image rec param
     kwargs_left = param_.InitAllowUnknown(kwargs);
@@ -50,9 +49,12 @@ class PrefetcherIter : public IIterator<DataBatch> {
     // maximum prefetch threaded iter internal size
     const int kMaxPrefetchBuffer = 16;
     // init thread iter
-    iter_.set_max_capacity(kMaxPrefetchBuffer);
+    iter.set_max_capacity(kMaxPrefetchBuffer);
+  }
 
-    iter_.Init([this](DataBatch **dptr) {
+  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+    InitParams(kwargs);
+    iter.Init([this](DataBatch **dptr) {
         if (!loader_->Next()) return false;
         const TBlobBatch& batch = loader_->Value();
         if (*dptr == nullptr) {
@@ -91,7 +93,7 @@ class PrefetcherIter : public IIterator<DataBatch> {
   }
 
   virtual void BeforeFirst(void) {
-    iter_.BeforeFirst();
+    iter.BeforeFirst();
   }
 
   virtual bool Next(void) {
@@ -106,9 +108,9 @@ class PrefetcherIter : public IIterator<DataBatch> {
         arr.WaitToWrite();
       }
       recycle_queue_.pop();
-      iter_.Recycle(&old_batch);
+      iter.Recycle(&old_batch);
     }
-    return iter_.Next(&out_);
+    return iter.Next(&out_);
   }
   virtual const DataBatch &Value(void) const {
     return *out_;
@@ -117,16 +119,16 @@ class PrefetcherIter : public IIterator<DataBatch> {
  protected:
   /*! \brief prefetcher parameters */
   PrefetcherParam param_;
-  /*! \brief internal batch loader */
-  std::unique_ptr<IIterator<TBlobBatch> > loader_;
+  /*! \brief backend thread */
+  dmlc::ThreadedIter<DataBatch> iter;
 
  private:
+  /*! \brief internal batch loader */
+  std::unique_ptr<IIterator<TBlobBatch> > loader_;
   /*! \brief output data */
   DataBatch *out_;
   /*! \brief queue to be recycled */
   std::queue<DataBatch*> recycle_queue_;
-  /*! \brief backend thread */
-  dmlc::ThreadedIter<DataBatch> iter_;
 };
 }  // namespace io
 }  // namespace mxnet

--- a/src/io/iter_sparse_batchloader.h
+++ b/src/io/iter_sparse_batchloader.h
@@ -1,0 +1,185 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file iter_sparse_batchloader.h
+ * \brief define a batch adapter to create sparse tblob batch
+ */
+#ifndef MXNET_IO_ITER_SPARSE_BATCHLOADER_H_
+#define MXNET_IO_ITER_SPARSE_BATCHLOADER_H_
+
+#include <mxnet/io.h>
+#include <mxnet/base.h>
+#include <dmlc/logging.h>
+#include <mshadow/tensor.h>
+#include <utility>
+#include <vector>
+#include <string>
+#include "./inst_vector.h"
+#include "./image_iter_common.h"
+#include "./iter_batchloader.h"
+
+namespace mxnet {
+namespace io {
+
+/*! \brief create a batch iterator from single instance iterator */
+class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch> {
+ public:
+  explicit SparseBatchLoader(SparseIIterator<DataInst> *base):
+      BatchLoader(base), sparse_base_(base) {
+  }
+
+  virtual ~SparseBatchLoader(void) {}
+
+  inline void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+    BatchLoader::Init(kwargs);
+    data_stype_ = sparse_base_->GetStorageType(true);
+    label_stype_ = sparse_base_->GetStorageType(false);
+    if (param.round_batch == 0) {
+      LOG(FATAL) << "sparse batch loader doesn't support round_batch == false yet";
+    }
+  }
+
+  virtual void BeforeFirst(void) {
+    BatchLoader::BeforeFirst();
+  }
+
+  virtual bool Next(void) {
+    out.num_batch_padd = 0;
+    out.batch_size = param.batch_size;
+    this->head = 0;
+    // if overflown from previous round, directly return false, until before first is called
+    if (num_overflow != 0) return false;
+    index_t top = 0;
+    inst_cache_.clear();
+    while (sparse_base_->Next()) {
+      inst_cache_.emplace_back(sparse_base_->Value());
+      if (inst_cache_.size() >= param.batch_size) break;
+    }
+    // no more data instance
+    if (inst_cache_.size() == 0) {
+      return false;
+    }
+    if (inst_cache_.size() < param.batch_size) {
+      CHECK_GT(param.round_batch, 0);
+      num_overflow = 0;
+      sparse_base_->BeforeFirst();
+      for (; inst_cache_.size() < param.batch_size; ++num_overflow) {
+        CHECK(sparse_base_->Next()) << "number of input must be bigger than batch size";
+        inst_cache_.emplace_back(sparse_base_->Value());
+      }
+    }
+    out.num_batch_padd = num_overflow;
+    CHECK_EQ(inst_cache_.size(), param.batch_size);
+    this->InitDataFromBatch();
+    MSHADOW_INT_TYPE_SWITCH(CSR_IND_PTR_TYPE, IType, {
+      for (size_t j = 0; j < inst_cache_.size(); j++) {
+        const auto& d = inst_cache_[j];
+        out.inst_index[top] = d.index;
+        size_t unit_size = 0;
+        for (size_t i = 0; i < d.data.size(); ++i) {
+          // indptr tensor
+          if (IsIndPtr(i)) {
+            auto indptr = data[i].get<cpu, 1, IType>();
+            if (j == 0) indptr[0] = 0;
+            indptr[j + 1] = indptr[j] + (IType) unit_size;
+            offsets_[i] = j;
+          } else {
+            // indices and values tensor
+            unit_size = d.data[i].shape_.Size();
+            MSHADOW_TYPE_SWITCH(data[i].type_flag_, DType, {
+              const auto begin = offsets_[i];
+              const auto end = offsets_[i] + unit_size;
+              mshadow::Copy(data[i].get<cpu, 1, DType>().Slice(begin, end),
+                            d.data[i].get_with_shape<cpu, 1, DType>(mshadow::Shape1(unit_size)));
+              });
+            offsets_[i] += unit_size;
+          }
+        }
+      }
+    });
+    return true;
+  }
+
+  virtual const TBlobBatch &Value(void) const {
+    return BatchLoader::Value();
+  }
+
+  virtual const NDArrayStorageType GetStorageType(bool is_data) const {
+    return sparse_base_->GetStorageType(is_data);
+  }
+
+  virtual const TShape GetShape(bool is_data) const {
+    TShape inst_shape = sparse_base_->GetShape(is_data);
+    std::vector<index_t> shape_vec;
+    shape_vec.push_back(param.batch_size);
+    for (index_t dim = 0; dim < inst_shape.ndim(); ++dim) {
+      shape_vec.push_back(inst_shape[dim]);
+    }
+    return TShape(shape_vec.begin(), shape_vec.end());
+  }
+
+ private:
+  /*! \brief base sparse iterator */
+  SparseIIterator<DataInst> *sparse_base_;
+  /*! \brief data instances */
+  std::vector<DataInst> inst_cache_;
+  /*! \brief data storage type */
+  NDArrayStorageType data_stype_;
+  /*! \brief data label type */
+  NDArrayStorageType label_stype_;
+  /*! \brief tensor offset for slicing */
+  std::vector<size_t> offsets_;
+
+  // check whether ith position is the indptr tensor for a CSR tensor
+  inline bool IsIndPtr(size_t i) {
+    auto data_num_aux = NDArray::NumAuxData(data_stype_);
+    auto label_num_aux = NDArray::NumAuxData(label_stype_);
+    auto label_indptr_offset = data_num_aux + 1 + label_num_aux;
+    // data indptr
+    if (i == data_num_aux && data_stype_ == kCSRStorage) {
+      return true;
+    }
+    // label indptr
+    if (i == label_indptr_offset && label_stype_ == kCSRStorage && data_stype_ == kCSRStorage) {
+      return true;
+    }
+    return false;
+  }
+
+  // initialize the data holder by using from the batch
+  inline void InitDataFromBatch() {
+    CHECK(data_stype_ == kCSRStorage || label_stype_ == kCSRStorage);
+    CHECK(inst_cache_.size() > 0);
+    out.data.clear();
+    offsets_.clear();
+
+    size_t total_size = inst_cache_[0].data.size();
+    data.resize(total_size);
+    offsets_.resize(total_size, 0);
+    std::vector<size_t> vec_sizes(total_size, 0);
+    // accumulate the memory required for a batch
+    for (size_t i = 0; i < total_size; ++i) {
+      size_t size = 0;
+      // vec_size for indptr
+      if (IsIndPtr(i)) {
+        size = param.batch_size + 1;
+      } else {
+        for (const auto &d : inst_cache_) size += d.data[i].shape_.Size();
+      }
+      vec_sizes[i] = size;
+    }
+
+    CHECK_EQ(vec_sizes[0], vec_sizes[1]);
+    for (size_t i = 0; i < total_size; ++i) {
+      int src_type_flag = inst_cache_[0].data[i].type_flag_;
+      // init object attributes
+      TShape dst_shape(mshadow::Shape1(vec_sizes[i]));
+      data[i].resize(mshadow::Shape1(vec_sizes[i]), src_type_flag);
+      CHECK(data[i].dptr_ != nullptr);
+      out.data.push_back(TBlob(data[i].dptr_, dst_shape, cpu::kDevMask, src_type_flag));
+    }
+  }
+
+};  // class BatchLoader
+}  // namespace io
+}  // namespace mxnet
+#endif  // MXNET_IO_ITER_SPARSE_BATCHLOADER_H_

--- a/src/io/iter_sparse_prefetcher.h
+++ b/src/io/iter_sparse_prefetcher.h
@@ -1,0 +1,133 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file iter_sparse_prefetcher.h
+ * \brief define a prefetcher using threaditer to keep k batch fetched
+ */
+#ifndef MXNET_IO_ITER_SPARSE_PREFETCHER_H_
+#define MXNET_IO_ITER_SPARSE_PREFETCHER_H_
+
+#include <mxnet/io.h>
+#include <mxnet/base.h>
+#include <mxnet/ndarray.h>
+#include <dmlc/logging.h>
+#include <dmlc/threadediter.h>
+#include <dmlc/optional.h>
+#include <mshadow/tensor.h>
+#include <climits>
+#include <utility>
+#include <string>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include "./inst_vector.h"
+#include "./image_iter_common.h"
+#include "./iter_prefetcher.h"
+
+namespace mxnet {
+namespace io {
+// iterator on sparse data
+class SparsePrefetcherIter : public PrefetcherIter {
+ public:
+  explicit SparsePrefetcherIter(SparseIIterator<TBlobBatch>* base)
+      : PrefetcherIter(base), sparse_loader_(base) {}
+
+  ~SparsePrefetcherIter() {}
+
+  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+    PrefetcherIter::InitParams(kwargs);
+    iter.Init([this](DataBatch **dptr) {
+        if (!sparse_loader_->Next()) return false;
+        const TBlobBatch& batch = sparse_loader_->Value();
+        if (*dptr == nullptr) {
+          // allocate databatch
+          *dptr = new DataBatch();
+          (*dptr)->num_batch_padd = batch.num_batch_padd;
+          // (*dptr)->data.at(0) => data
+          // (*dptr)->data.at(1) => label
+          (*dptr)->data.resize(2);
+          (*dptr)->index.resize(batch.batch_size);
+          size_t data_iter = 0;
+          for (size_t i = 0; i < (*dptr)->data.size(); ++i) {
+            bool is_data = i == 0;
+            auto stype = this->GetStorageType(is_data);
+            auto dtype = param_.dtype ? param_.dtype.value() : batch.data[data_iter].type_flag_;
+            if (stype == kDefaultStorage) {
+              (*dptr)->data.at(i) = NDArray(batch.data[data_iter].shape_,
+                                            Context::CPU(), false, dtype);
+            } else {
+              (*dptr)->data.at(i) = NDArray(stype, this->GetShape(is_data),
+                                            Context::CPU(), false, dtype);
+            }
+            data_iter += NDArray::NumAuxData(stype) + 1;
+          }
+        }
+        // copy data over
+        size_t data_iter = 0;
+        for (size_t i = 0; i < (*dptr)->data.size(); ++i) {
+          auto& nd = ((*dptr)->data)[i];
+          auto stype = nd.storage_type();
+          auto& data_i = ((*dptr)->data)[i];
+          if (stype == kDefaultStorage) {
+            CopyFromTo(data_i.data(), batch.data[data_iter]);
+          } else if (stype == kCSRStorage){
+            auto& values = batch.data[data_iter];
+            auto& indices = batch.data[data_iter + 1];
+            auto& indptr = batch.data[data_iter + 2];
+            // allocate memory
+            CHECK_EQ(indices.shape_.Size(),values.shape_.Size());
+            nd.CheckAndAllocAuxData(csr::kIdx, indices.shape_);
+            nd.CheckAndAllocData(values.shape_);
+            nd.CheckAndAllocAuxData(csr::kIndPtr, indptr.shape_);
+            // copy values, indices and indptr
+            CopyFromTo(data_i.data(), values);
+            CopyFromTo(data_i.aux_data(csr::kIdx), indices);
+            CopyFromTo(data_i.aux_data(csr::kIndPtr), indptr);
+          } else {
+            LOG(FATAL) << "Storage type not implemented: " << stype;
+          }
+          data_iter += NDArray::NumAuxData(stype) + 1;
+          (*dptr)->num_batch_padd = batch.num_batch_padd;
+        }
+        if (batch.inst_index) {
+          std::copy(batch.inst_index,
+                    batch.inst_index + batch.batch_size,
+                    (*dptr)->index.begin());
+        }
+       return true;
+      },
+      [this]() { sparse_loader_->BeforeFirst(); });
+  }
+
+  virtual void BeforeFirst(void) {
+    PrefetcherIter::BeforeFirst();
+  }
+
+  virtual bool Next(void) {
+    return PrefetcherIter::Next();
+  }
+  virtual const DataBatch &Value(void) const {
+    return PrefetcherIter::Value();
+  }
+
+  virtual const NDArrayStorageType GetStorageType(bool is_data) const {
+    return sparse_loader_->GetStorageType(is_data);
+  }
+
+  virtual const TShape GetShape(bool is_data) const {
+    return sparse_loader_->GetShape(is_data);
+  }
+
+ private:
+  /*! \brief internal sparse batch loader */
+  SparseIIterator<TBlobBatch>* sparse_loader_;
+
+  inline void CopyFromTo(TBlob dst, const TBlob src) {
+    MSHADOW_TYPE_SWITCH(src.type_flag_, DType, {
+      mshadow::Copy(dst.FlatTo1D<cpu, DType>(), src.FlatTo1D<cpu, DType>());
+    });
+  }
+
+};
+}  // namespace io
+}  // namespace mxnet
+#endif  // MXNET_IO_ITER_SPARSE_PREFETCHER_H_

--- a/tests/python/train/test_sparse.py
+++ b/tests/python/train/test_sparse.py
@@ -1,0 +1,91 @@
+# pylint: skip-file
+import mxnet as mx
+from mxnet.test_utils import *
+import numpy as np
+import scipy.sparse as sp
+import os, gzip
+import pickle as pickle
+import time
+import sys
+from common import get_data
+
+def test_dot_real(dataset):
+    def get_iter(path, data_shape, batch_size):
+        data_train = mx.io.LibSVMIter(data_libsvm=path,
+                                      data_shape=data_shape,
+                                      batch_size=batch_size)
+        data_iter = iter(data_train)
+        return data_iter
+
+    batch_size = 512
+    if dataset == 'train':
+        size = 2858375979 >> 20
+        path = "/home/ubuntu/svm/avazu-app"
+    elif dataset == 'test':
+        size = 336490781 >> 20
+        path = "/home/ubuntu/svm/avazu-app.t"
+    else:
+        raise Exception('unknown dataset')
+
+    # model
+    feature_dim = 1000000
+    data_shape = (feature_dim, )
+    train_iter = get_iter(path, data_shape, batch_size)
+
+    k = 500
+    weight = mx.nd.random_uniform(low=0, high=1, shape=(feature_dim, k)) 
+    weight.wait_to_read()
+
+    # start workload
+    start = time.time()
+    results = []
+    num_batch = 0
+    for batch in train_iter:
+        data = train_iter.getdata()
+        results.append(mx.nd.dot(data, weight))
+        num_batch += 1
+    for result in results:
+        result.wait_to_read()
+
+    end = time.time()
+    duration = end - start
+    print(size / duration, duration, num_batch, num_batch / duration)
+
+def test_dot_synthetic():
+    def bench_dot(m, k, n, density):
+        weight = mx.nd.random_uniform(low=0, high=1, shape=(k, n))
+        data_shape = (m, k)
+
+        csr_data = rand_ndarray(data_shape, 'csr', density)
+        dns_data = csr_data.to_dense()
+        num_iter = 50
+
+        data = [dns_data, csr_data]
+        durations = []
+        for d in data:
+            weight.wait_to_read()
+            d.wait_to_read()
+            # start bench
+            start = time.time()
+            results = []
+            for i in range(num_iter):
+                results.append(mx.nd.dot(d, weight))
+            for result in results:
+                result.wait_to_read()
+            end = time.time()
+            duration = end - start
+            durations.append(duration)
+        ratio = durations[1] / durations[0]
+        print("%0.2f\t%d\t%d\t%d\t%0.3f" % (density, n, m, k, ratio))
+
+    print('density\tn\tm\tk\tt_sparse/t_dense')
+    m = 512
+    k = 50000
+    n = 50
+    density = [0.8, 0.5, 0.2, 0.1, 0.01, 0.001]
+    for den in density:
+        bench_dot(m, k, n, den)
+
+if __name__ == "__main__":
+    #test_dot_real('test')
+    test_dot_synthetic()

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -1,5 +1,6 @@
 # pylint: skip-file
 import mxnet as mx
+from mxnet.test_utils import *
 import numpy as np
 import os, gzip
 import pickle as pickle
@@ -88,7 +89,37 @@ def test_NDArrayIter():
         else:
             assert(labelcount[i] == 100)
 
+def test_libsvm():
+    #TODO(haibin) automatic the test instead of hard coded test
+    with open('data.t', 'w') as fout:
+        fout.write('1.0 0:0.5 2:1.2\n')
+        fout.write('-2.0\n')
+        fout.write('-3.0 0:0.6 1:2.4 2:1.2\n')
+        fout.write('4 2:-1.2\n')
+
+    with open('label.t', 'w') as fout:
+        fout.write('1.0\n')
+        fout.write('-2.0 0:0.125\n')
+        fout.write('-3.0 2:1.2\n')
+        fout.write('4 1:1.0 2:-1.2\n')
+
+    f = ("/home/ubuntu/svm/data.t", "/home/ubuntu/svm/label.t", (3,), (3,), 3)
+    data_train = mx.io.LibSVMIter(data_libsvm=f[0],
+                                  label_libsvm=f[1],
+                                  data_shape=f[2],
+                                  label_shape=f[3],
+                                  batch_size=f[4])
+
+    first = mx.nd.array([[ 0.5, 0., 1.2], [ 0., 0., 0.], [ 0.6, 2.4, 1.2]])
+    second = mx.nd.array([[ 0., 0., -1.2], [ 0.5, 0., 1.2], [ 0., 0., 0.]])
+    i = 0
+    for batch in iter(data_train):
+        expected = first.asnumpy() if i == 0 else second.asnumpy()
+        assert_almost_equal(data_train.getdata().asnumpy(), expected)
+        i += 1
+
 if __name__ == "__main__":
     test_NDArrayIter()
     test_MNISTIter()
     test_Cifar10Rec()
+    test_libsvm()


### PR DESCRIPTION
Setup: `p2.8xlarge`, compiled with 
```
USE_OPENMP=1, DEV=0, DEBUG=0, USE_MKL2017=0, USE_MKL2017_EXPERIMENTAL=0, USE_BLAS=openblas
```

```
ubuntu@ip-172-31-33-77:~ $ python ./benchmark/python/sparse_op.py
A = sparse NDArray of shape(m, k)
B = dense NDArray of shape(k, n)

dot_forward     dot(csr, dns)
density(%)      context n       m       k       t_sparse        t_dense t_sparse/t_dense
5.0             cpu(0)  50      512     50000   0.107473        0.07950 1.35
2.0             cpu(0)  50      512     50000   0.037989        0.04614 0.82
1.0             cpu(0)  50      512     50000   0.019648        0.04613 0.43
0.5             cpu(0)  50      512     50000   0.010569        0.04618 0.23
0.1             cpu(0)  50      512     50000   0.002689        0.04633 0.06

5.0             cpu(0)  100     512     100000  0.706307        0.07776 9.08
2.0             cpu(0)  100     512     100000  0.175632        0.07767 2.26
1.0             cpu(0)  100     512     100000  0.081770        0.07748 1.06
0.5             cpu(0)  100     512     100000  0.044006        0.07770 0.57
0.1             cpu(0)  100     512     100000  0.010350        0.07731 0.13

dot_backward    dot(csr.T, dns)
density(%)      context n       m       k       t_sparse        t_dense t_sparse/t_dense
5.0             cpu(0)  50      512     50000   89.038583       0.05922 1503.65
2.0             cpu(0)  50      512     50000   74.109367       0.05911 1253.69
1.0             cpu(0)  50      512     50000   71.950517       0.05902 1219.13
0.5             cpu(0)  50      512     50000   55.482324       0.05920 937.19
0.1             cpu(0)  50      512     50000   24.582513       0.05941 413.74
```

@reminisce the time reported for dot(csr.T, dns) report by the script is very slow. Did you notice this before?

