### PR TITLE
add storage cast for outputs that have non-default storage

### DIFF
--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -326,11 +326,13 @@ void FCompExFallback(const nnvm::NodeAttrs& attrs,
                      const std::vector<NDArray>& outputs,
                      FCompute fcompute,
                      const std::string& fname) {
+  using namespace common;
   std::vector<TBlob> in_blobs, out_blobs;
-  std::vector<NDArray> tmps;
-  common::GetInputBlobs<xpu>(inputs, &in_blobs, &tmps, ctx, true);
-  common::GetOutputBlobs<xpu>(outputs, &out_blobs);
+  std::vector<NDArray> temp_in, temp_out;
+  GetDefaultBlobs<xpu>(inputs, &in_blobs, &temp_in, ctx, true);
+  GetDefaultBlobs<xpu>(outputs, &out_blobs, &temp_out, ctx, true);
   fcompute(attrs, ctx, in_blobs, req, out_blobs);
+  CastNonDefaultStorage<xpu>(outputs, temp_out, ctx, true);
 }
 
 

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -265,6 +265,12 @@ def test_sparse_nd_negate():
     # we compute (-arr)
     assert_almost_equal(npy, arr.asnumpy())
 
+def test_sparse_nd_output_fallback():
+    shape = (10, 10)
+    out = mx.sparse_nd.zeros('row_sparse', shape)
+    mx.nd.random_normal(shape=shape, out=out)
+    assert(np.sum(out.asnumpy()) != 0)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
make code changes to support non-default storage output of an FCompute:
```
   out = mx.sparse_nd.zeros('row_sparse', shape)
   mx.nd.random_normal(shape=shape, out=out)
```
We need to cast it back to rsp once FCompute finishes.