### PR TITLE
Add unit test

### DIFF
--- a/python/mxnet/sparse_ndarray.py
+++ b/python/mxnet/sparse_ndarray.py
@@ -84,44 +84,44 @@ class SparseNDArray(NDArray):
     fixed-size items, stored in sparse format. See CSRNDArray and RowSparseNDArray
     for more details.
     """
-    def __add__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __add__(self, other):
+        # raise Exception('Not implemented for SparseND yet!')
 
     def __iadd__(self, other):
         raise Exception('Not implemented for SparseND yet!')
 
-    def __radd__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __radd__(self, other):
+    #     raise Exception('Not implemented for SparseND yet!')
 
     def __isub__(self, other):
         raise Exception('Not implemented for SparseND yet!')
 
-    def __rsub__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __rsub__(self, other):
+    #     raise Exception('Not implemented for SparseND yet!')
 
     def __imul__(self, other):
         raise Exception('Not implemented for SparseND yet!')
 
-    def __rmul__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __rmul__(self, other):
+    #     raise Exception('Not implemented for SparseND yet!')
 
-    def __rdiv__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __rdiv__(self, other):
+    #    raise Exception('Not implemented for SparseND yet!')
 
     def __idiv__(self, other):
         raise Exception('Not implemented for SparseND yet!')
 
-    def __rtruediv__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __rtruediv__(self, other):
+    #    raise Exception('Not implemented for SparseND yet!')
 
     def __itruediv__(self, other):
         raise Exception('Not implemented for SparseND yet!')
 
-    def __pow__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __pow__(self, other):
+    #    raise Exception('Not implemented for SparseND yet!')
 
-    def __rpow__(self, other):
-        raise Exception('Not implemented for SparseND yet!')
+    # def __rpow__(self, other):
+    #     raise Exception('Not implemented for SparseND yet!')
 
     def __setitem__(self, key, value):
         """x.__setitem__(i, y) <=> x[i]=y

--- a/python/mxnet/sparse_ndarray.py
+++ b/python/mxnet/sparse_ndarray.py
@@ -84,44 +84,20 @@ class SparseNDArray(NDArray):
     fixed-size items, stored in sparse format. See CSRNDArray and RowSparseNDArray
     for more details.
     """
-    # def __add__(self, other):
-        # raise Exception('Not implemented for SparseND yet!')
-
     def __iadd__(self, other):
         raise Exception('Not implemented for SparseND yet!')
-
-    # def __radd__(self, other):
-    #     raise Exception('Not implemented for SparseND yet!')
 
     def __isub__(self, other):
         raise Exception('Not implemented for SparseND yet!')
 
-    # def __rsub__(self, other):
-    #     raise Exception('Not implemented for SparseND yet!')
-
     def __imul__(self, other):
         raise Exception('Not implemented for SparseND yet!')
-
-    # def __rmul__(self, other):
-    #     raise Exception('Not implemented for SparseND yet!')
-
-    # def __rdiv__(self, other):
-    #    raise Exception('Not implemented for SparseND yet!')
 
     def __idiv__(self, other):
         raise Exception('Not implemented for SparseND yet!')
 
-    # def __rtruediv__(self, other):
-    #    raise Exception('Not implemented for SparseND yet!')
-
     def __itruediv__(self, other):
         raise Exception('Not implemented for SparseND yet!')
-
-    # def __pow__(self, other):
-    #    raise Exception('Not implemented for SparseND yet!')
-
-    # def __rpow__(self, other):
-    #     raise Exception('Not implemented for SparseND yet!')
 
     def __setitem__(self, key, value):
         """x.__setitem__(i, y) <=> x[i]=y

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -243,7 +243,7 @@ def test_sparse_nd_lesser_equal():
 
 
 def test_sparse_nd_binary():
-    N = 100
+    N = 1
     def check_binary(fn):
         for _ in range(N):
             ndim = 2
@@ -257,23 +257,51 @@ def test_sparse_nd_binary():
                     lshape[ndim-i-1] = 1
                 elif sep < 0.66:
                     rshape[bdim-i-1] = 1
-            lhs = np.random.normal(0, 1, size=lshape)
-            rhs = np.random.normal(0, 1, size=rshape)
+            lhs = np.random.uniform(0, 1, size=lshape)
+            rhs = np.random.uniform(0, 1, size=rshape)
             lhs_nd = mx.nd.array(lhs).to_csr()
             rhs_nd = mx.nd.array(rhs).to_csr()
             assert_allclose(fn(lhs, rhs),
                             fn(lhs_nd, rhs_nd).asnumpy(),
                             rtol=1e-4, atol=1e-4)
 
-    #check_binary(lambda x, y: x + y)
+    check_binary(lambda x, y: x + y)
     check_binary(lambda x, y: x - y)
     check_binary(lambda x, y: x * y)
     check_binary(lambda x, y: x / y)
+    check_binary(lambda x, y: x ** y)
     check_binary(lambda x, y: x > y)
     check_binary(lambda x, y: x < y)
     check_binary(lambda x, y: x >= y)
     check_binary(lambda x, y: x <= y)
     check_binary(lambda x, y: x == y)
+
+
+def test_sparse_nd_rhs_op_overload():
+    N = 100
+    def check(fn):
+        for _ in range(N):
+            ndim = 2
+            shape = np.random.randint(1, 6, size=(ndim,))
+            np_nd = np.random.normal(0, 1, size=shape)
+            csr_nd = mx.nd.array(np_nd).to_csr()
+            assert_allclose(
+                fn(np_nd),
+                fn(csr_nd).asnumpy(),
+                rtol=1e-4,
+                atol=1e-4
+            )
+    check(lambda x: 1 + x)
+    check(lambda x: 1 - x)
+    check(lambda x: 1 * x)
+    check(lambda x: 1 / x)
+    check(lambda x: 2 ** x)
+    check(lambda x: 1 > x)
+    check(lambda x: 0.5 > x)
+    check(lambda x: 0.5 < x)
+    check(lambda x: 0.5 >= x)
+    check(lambda x: 0.5 <= x)
+    check(lambda x: 0.5 == x)
 
 
 def test_sparse_nd_negate():

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -243,7 +243,7 @@ def test_sparse_nd_lesser_equal():
 
 
 def test_sparse_nd_binary():
-    N = 1
+    N = 100
     def check_binary(fn):
         for _ in range(N):
             ndim = 2

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -277,7 +277,7 @@ def test_sparse_nd_binary():
     check_binary(lambda x, y: x == y)
 
 
-def test_sparse_nd_rhs_op_overload():
+def test_sparse_nd_binary_rop():
     N = 100
     def check(fn):
         for _ in range(N):

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -165,81 +165,81 @@ def test_sparse_nd_slice():
 
 
 def test_sparse_nd_equal():
-    stype = 'csr'
-    shape = rand_shape_2d()
-    x = mx.sparse_nd.zeros(stype, shape)
-    y = sparse_nd_ones(shape, stype)
-    z = x == y
-    assert (z.asnumpy() == np.zeros(shape)).all()
-    z = 0 == x
-    assert (z.asnumpy() == np.ones(shape)).all()
+    for stype in ['row_sparse', 'csr']:
+        shape = rand_shape_2d()
+        x = mx.sparse_nd.zeros(stype, shape)
+        y = sparse_nd_ones(shape, stype)
+        z = x == y
+        assert (z.asnumpy() == np.zeros(shape)).all()
+        z = 0 == x
+        assert (z.asnumpy() == np.ones(shape)).all()
 
 
 def test_sparse_nd_not_equal():
-    stype = 'csr'
-    shape = rand_shape_2d()
-    x = mx.sparse_nd.zeros(stype, shape)
-    y = sparse_nd_ones(shape, stype)
-    z = x != y
-    assert (z.asnumpy() == np.ones(shape)).all()
-    z = 0 != x
-    assert (z.asnumpy() == np.zeros(shape)).all()
+    for stype in ['row_sparse', 'csr']:
+        shape = rand_shape_2d()
+        x = mx.sparse_nd.zeros(stype, shape)
+        y = sparse_nd_ones(shape, stype)
+        z = x != y
+        assert (z.asnumpy() == np.ones(shape)).all()
+        z = 0 != x
+        assert (z.asnumpy() == np.zeros(shape)).all()
 
 
 def test_sparse_nd_greater():
-    stype = 'csr'
-    shape = rand_shape_2d()
-    x = mx.sparse_nd.zeros(stype, shape)
-    y = sparse_nd_ones(shape, stype)
-    z = x > y
-    assert (z.asnumpy() == np.zeros(shape)).all()
-    z = y > 0
-    assert (z.asnumpy() == np.ones(shape)).all()
-    z = 0 > y
-    assert (z.asnumpy() == np.zeros(shape)).all()
+    for stype in ['row_sparse', 'csr']:
+        shape = rand_shape_2d()
+        x = mx.sparse_nd.zeros(stype, shape)
+        y = sparse_nd_ones(shape, stype)
+        z = x > y
+        assert (z.asnumpy() == np.zeros(shape)).all()
+        z = y > 0
+        assert (z.asnumpy() == np.ones(shape)).all()
+        z = 0 > y
+        assert (z.asnumpy() == np.zeros(shape)).all()
 
 
 def test_sparse_nd_greater_equal():
-    stype = 'csr'
-    shape = rand_shape_2d()
-    x = mx.sparse_nd.zeros(stype, shape)
-    y = sparse_nd_ones(shape, stype)
-    z = x >= y
-    assert (z.asnumpy() == np.zeros(shape)).all()
-    z = y >= 0
-    assert (z.asnumpy() == np.ones(shape)).all()
-    z = 0 >= y
-    assert (z.asnumpy() == np.zeros(shape)).all()
-    z = y >= 1
-    assert (z.asnumpy() == np.ones(shape)).all()
+    for stype in ['row_sparse', 'csr']:
+        shape = rand_shape_2d()
+        x = mx.sparse_nd.zeros(stype, shape)
+        y = sparse_nd_ones(shape, stype)
+        z = x >= y
+        assert (z.asnumpy() == np.zeros(shape)).all()
+        z = y >= 0
+        assert (z.asnumpy() == np.ones(shape)).all()
+        z = 0 >= y
+        assert (z.asnumpy() == np.zeros(shape)).all()
+        z = y >= 1
+        assert (z.asnumpy() == np.ones(shape)).all()
 
 
 def test_sparse_nd_lesser():
-    stype = 'csr'
-    shape = rand_shape_2d()
-    x = mx.sparse_nd.zeros(stype, shape)
-    y = sparse_nd_ones(shape, stype)
-    z = y < x
-    assert (z.asnumpy() == np.zeros(shape)).all()
-    z = 0 < y
-    assert (z.asnumpy() == np.ones(shape)).all()
-    z = y < 0
-    assert (z.asnumpy() == np.zeros(shape)).all()
+    for stype in ['row_sparse', 'csr']:
+        shape = rand_shape_2d()
+        x = mx.sparse_nd.zeros(stype, shape)
+        y = sparse_nd_ones(shape, stype)
+        z = y < x
+        assert (z.asnumpy() == np.zeros(shape)).all()
+        z = 0 < y
+        assert (z.asnumpy() == np.ones(shape)).all()
+        z = y < 0
+        assert (z.asnumpy() == np.zeros(shape)).all()
 
 
 def test_sparse_nd_lesser_equal():
-    stype = 'csr'
-    shape = rand_shape_2d()
-    x = mx.sparse_nd.zeros(stype, shape)
-    y = sparse_nd_ones(shape, stype)
-    z = y <= x
-    assert (z.asnumpy() == np.zeros(shape)).all()
-    z = 0 <= y
-    assert (z.asnumpy() == np.ones(shape)).all()
-    z = y <= 0
-    assert (z.asnumpy() == np.zeros(shape)).all()
-    z = 1 <= y
-    assert (z.asnumpy() == np.ones(shape)).all()
+    for stype in ['row_sparse', 'csr']:
+        shape = rand_shape_2d()
+        x = mx.sparse_nd.zeros(stype, shape)
+        y = sparse_nd_ones(shape, stype)
+        z = y <= x
+        assert (z.asnumpy() == np.zeros(shape)).all()
+        z = 0 <= y
+        assert (z.asnumpy() == np.ones(shape)).all()
+        z = y <= 0
+        assert (z.asnumpy() == np.zeros(shape)).all()
+        z = 1 <= y
+        assert (z.asnumpy() == np.ones(shape)).all()
 
 
 def test_sparse_nd_binary():
@@ -259,11 +259,14 @@ def test_sparse_nd_binary():
                     rshape[bdim-i-1] = 1
             lhs = np.random.uniform(0, 1, size=lshape)
             rhs = np.random.uniform(0, 1, size=rshape)
-            lhs_nd = mx.nd.array(lhs).to_csr()
-            rhs_nd = mx.nd.array(rhs).to_csr()
-            assert_allclose(fn(lhs, rhs),
-                            fn(lhs_nd, rhs_nd).asnumpy(),
-                            rtol=1e-4, atol=1e-4)
+            lhs_nd_csr = mx.nd.array(lhs).to_csr()
+            rhs_nd_csr = mx.nd.array(rhs).to_csr()
+            lhs_nd_rsp = mx.nd.array(lhs).to_rsp()
+            rhs_nd_rsp = mx.nd.array(rhs).to_rsp()
+            for lhs_nd, rhs_nd in [(lhs_nd_csr, rhs_nd_csr), (lhs_nd_rsp, rhs_nd_rsp)]:
+                assert_allclose(fn(lhs, rhs),
+                                fn(lhs_nd, rhs_nd).asnumpy(),
+                                rtol=1e-4, atol=1e-4)
 
     check_binary(lambda x, y: x + y)
     check_binary(lambda x, y: x - y)
@@ -283,14 +286,16 @@ def test_sparse_nd_binary_rop():
         for _ in range(N):
             ndim = 2
             shape = np.random.randint(1, 6, size=(ndim,))
-            np_nd = np.random.normal(0, 1, size=shape)
-            csr_nd = mx.nd.array(np_nd).to_csr()
-            assert_allclose(
-                fn(np_nd),
-                fn(csr_nd).asnumpy(),
-                rtol=1e-4,
-                atol=1e-4
-            )
+            npy_nd = np.random.normal(0, 1, size=shape)
+            csr_nd = mx.nd.array(npy_nd).to_csr()
+            rsp_nd = mx.nd.array(npy_nd).to_rsp()
+            for sparse_nd in [csr_nd, rsp_nd]:
+                assert_allclose(
+                    fn(npy_nd),
+                    fn(sparse_nd).asnumpy(),
+                    rtol=1e-4,
+                    atol=1e-4
+                )
     check(lambda x: 1 + x)
     check(lambda x: 1 - x)
     check(lambda x: 1 * x)
@@ -306,14 +311,16 @@ def test_sparse_nd_binary_rop():
 
 def test_sparse_nd_negate():
     npy = np.random.uniform(-10, 10, rand_shape_2d())
-    arr = mx.nd.array(npy).to_csr()
-    assert_almost_equal(npy, arr.asnumpy())
-    assert_almost_equal(-npy, (-arr).asnumpy())
+    arr_csr = mx.nd.array(npy).to_csr()
+    arr_rsp = mx.nd.array(npy).to_rsp()
+    for arr in [arr_csr, arr_rsp]:
+        assert_almost_equal(npy, arr.asnumpy())
+        assert_almost_equal(-npy, (-arr).asnumpy())
 
-    # a final check to make sure the negation (-) is not implemented
-    # as inplace operation, so the contents of arr does not change after
-    # we compute (-arr)
-    assert_almost_equal(npy, arr.asnumpy())
+        # a final check to make sure the negation (-) is not implemented
+        # as inplace operation, so the contents of arr does not change after
+        # we compute (-arr)
+        assert_almost_equal(npy, arr.asnumpy())
 
 
 def test_sparse_nd_output_fallback():


### PR DESCRIPTION
add unittests for some op overloading in sparse nd array.
test_sparse_ndarray.py line 260 change from np.random.normal to np.random.uniform is because negative number take power like 0.5 will cause runtime warning. 
