### PR TITLE
ignoring variables in SimpleBind that is used on python's sparse branch for now.

### DIFF
--- a/perl-package/AI-MXNetCAPI/mxnet.i
+++ b/perl-package/AI-MXNetCAPI/mxnet.i
@@ -1196,6 +1196,12 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
                          const mx_uint num_provided_arg_dtypes,
                          const char** in, // provided_arg_dtype_names,
                          const int* in, // provided_arg_dtypes,
+
+//---------------        sparse related variables, ignored for now
+                         const mx_uint num_provided_arg_stypes,
+                         const char** provided_arg_stype_names,
+                         const int* provided_arg_stypes,
+//---------------
                          const mx_uint num_shared_arg_names,
                          const char** in, // shared_arg_name_list,
 //------------

--- a/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
+++ b/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
@@ -820,6 +820,17 @@
     }
 }
 
+%typemap(in,numinputs=0) (const mx_uint num_provided_arg_stypes, const char** provided_arg_stype_names,
+                          const int* provided_arg_stypes)
+                         (mx_uint temp1, char* temp2, int temp3)
+{
+    $2 = &temp2;
+    $3 = &temp3;
+    $1 = 0;
+    *$2 = NULL;
+    *$3 = 0;
+}
+
 %typemap(in,numinputs=0) (mx_uint* num_aux_states,
                           NDArrayHandle** aux_states)
                          (mx_uint temp1,


### PR DESCRIPTION
This should help, but my test run had one error in test_model_parallel but I do not think it's any related to the patch and something else on your branch.
```
t/test_model_parallel.t ..... [15:35:38] /home/developer/mxnet/dmlc-core/include/dmlc/logging.h:308: [15:35:38] src/executor/graph_executor.cc:391: Check failed: ctx == vcontext[nid] Trying to save gradient to cpu(0) while its source node "sum_grad" computes it on cpu(1). Check your ctx in NDArray allocation.

Stack trace returned 10 entries:
[bt] (0) /home/developer/mxnet/perl-package/AI-MXNetCAPI/../../lib/libmxnet.so(_ZN4dmlc15LogMessageFatalD1Ev+0x3c) [0x2b908046d6fc]
[bt] (1) /home/developer/mxnet/perl-package/AI-MXNetCAPI/../../lib/libmxnet.so(_ZN5mxnet4exec13AssignContextEN4nnvm5GraphERKNS_7ContextERKSt3mapISsS3_St4lessISsESaISt4pairIKSsS3_EEERKSt6vectorIS3_SaIS3_EESK_SK_mm+0x17cd) [0x2b90812c958d]
[bt] (2) /home/developer/mxnet/perl-package/AI-MXNetCAPI/../../lib/libmxnet.so(_ZN5mxnet4exec13GraphExecutor9InitGraphEN4nnvm6SymbolERKNS_7ContextERKSt3mapISsS4_St4lessISsESaISt4pairIKSsS4_EEERKSt6vectorIS4_SaIS4_EESL_SL_RKSH_INS_9OpReqTypeESaISM_EE+0xaf) [0x2b90812d3fef]
[bt] (3) /home/developer/mxnet/perl-package/AI-MXNetCAPI/../../lib/libmxnet.so(_ZN5mxnet4exec13GraphExecutor4InitEN4nnvm6SymbolERKNS_7ContextERKSt3mapISsS4_St4lessISsESaISt4pairIKSsS4_EEERKSt6vectorINS_7NDArrayESaISI_EESM_RKSH_INS_9OpReqTypeESaISN_EESM_PNS_8ExecutorERKSt13unordered_mapINS2_9NodeEntryESI_NS2_13NodeEntryHashENS2_14NodeEntryEqualESaISA_IKSV_SI_EEE+0x6b1) [0x2b90812d4891]
[bt] (4) /home/developer/mxnet/perl-package/AI-MXNetCAPI/../../lib/libmxnet.so(_ZN5mxnet8Executor4BindEN4nnvm6SymbolERKNS_7ContextERKSt3mapISsS3_St4lessISsESaISt4pairIKSsS3_EEERKSt6vectorINS_7NDArrayESaISH_EESL_RKSG_INS_9OpReqTypeESaISM_EESL_PS0_+0x124) [0x2b90812d5c74]
[bt] (5) /home/developer/mxnet/perl-package/AI-MXNetCAPI/../../lib/libmxnet.so(MXExecutorBindEX+0x9d1) [0x2b9081258671]
[bt] (6) /home/developer/perl5/lib/perl5/x86_64-linux-gnu-thread-multi/auto/AI/MXNetCAPI/MXNetCAPI.so(_wrap_ExecutorBindEX+0x694) [0x2b907ffaf874]
[bt] (7) /usr/lib/libperl.so.5.18(Perl_pp_entersub+0x596) [0x2b907c2e2c46]
[bt] (8) /usr/lib/libperl.so.5.18(Perl_runops_standard+0x16) [0x2b907c2db266]
[bt] (9) /usr/lib/libperl.so.5.18(perl_run+0x384) [0x2b907c273b44]
```