### PR TITLE
support storage fallback with mutable inputs

### DIFF
--- a/python/mxnet/ndarray/__init__.py
+++ b/python/mxnet/ndarray/__init__.py
@@ -6,5 +6,5 @@ from .op import CachedOp
 # pylint: disable=wildcard-import
 from .ndarray import *
 from .ndarray_utils import load, save, zeros, empty, array
-from .sparse_ndarray import _ndarray_cls
-from .sparse_ndarray import csr, row_sparse, BaseSparseNDArray, todense, RowSparseNDArray, CSRNDArray
+from .sparse_ndarray import _ndarray_cls, todense
+from .sparse_ndarray import csr, row_sparse, BaseSparseNDArray, RowSparseNDArray, CSRNDArray

--- a/python/mxnet/ndarray/sparse_ndarray.py
+++ b/python/mxnet/ndarray/sparse_ndarray.py
@@ -408,11 +408,11 @@ class CSRNDArray(BaseSparseNDArray):
             value and ``other`` will point to the same ``NDArray`` or ``CSRNDArray``.
         """
         if isinstance(other, Context):
-            super(CSRNDArray, self).copyto(other)
+            return super(CSRNDArray, self).copyto(other)
         elif isinstance(other, NDArray):
             stype = other.stype
             if stype == 'default' or stype == 'csr':
-                super(CSRNDArray, self).copyto(other)
+                return super(CSRNDArray, self).copyto(other)
             else:
                 raise TypeError('copyto does not support destination NDArray stype ' + str(stype))
         else:
@@ -597,11 +597,11 @@ class RowSparseNDArray(BaseSparseNDArray):
             return value and ``other`` will point to the same ``NDArray`` or ``RowSparseNDArray``.
         """
         if isinstance(other, Context):
-            super(RowSparseNDArray, self).copyto(other)
+            return super(RowSparseNDArray, self).copyto(other)
         elif isinstance(other, NDArray):
             stype = other.stype
             if stype == 'default' or stype == 'row_sparse':
-                super(RowSparseNDArray, self).copyto(other)
+                return super(RowSparseNDArray, self).copyto(other)
             else:
                 raise TypeError('copyto does not support destination NDArray stype ' + str(stype))
         else:

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -543,8 +543,10 @@ class Adam(Optimizer):
         self.epsilon = epsilon
 
     def create_state(self, index, weight):
-        return (zeros(weight.shape, weight.context, dtype=weight.dtype),  # mean
-                zeros(weight.shape, weight.context, dtype=weight.dtype))  # variance
+        return (zeros(weight.shape, weight.context, dtype=weight.dtype,
+                      stype=weight.stype),  # mean
+                zeros(weight.shape, weight.context, dtype=weight.dtype,
+                      stype=weight.stype))  # variance
 
     def update(self, index, weight, grad, state):
         assert(isinstance(weight, NDArray))
@@ -649,11 +651,11 @@ class RMSProp(Optimizer):
     def create_state(self, index, weight):
         if self.centered:
             return (
-                zeros(weight.shape, weight.context),  # n
-                zeros(weight.shape, weight.context),  # g
-                zeros(weight.shape, weight.context))  # delta
+                zeros(weight.shape, weight.context, stype=weight.stype),  # n
+                zeros(weight.shape, weight.context, stype=weight.stype),  # g
+                zeros(weight.shape, weight.context, stype=weight.stype))  # delta
         else:
-            return (zeros(weight.shape, weight.context),)  # n
+            return (zeros(weight.shape, weight.context, stype=weight.stype),)  # n
 
     def update(self, index, weight, grad, state):
         assert(isinstance(weight, NDArray))

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -418,7 +418,7 @@ void PushOperator(const OpStatePtr& state,
 #if MXNET_USE_CUDA
           CastNonDefaultStorage<gpu>(pre_temp_src, pre_temp_dst, opctx);
           fcompute(state, opctx, input_blobs, req, output_blobs);
-          CastNonDefaultStorage<gpu>(temp_out_dst, post_temp_dst, opctx);
+          CastNonDefaultStorage<gpu>(post_temp_src, post_temp_dst, opctx);
 #else
           LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -311,8 +311,9 @@ void PushFCompute(const FCompute& fn,
       SetupDefaultBlobs(ndoutputs, &output_blobs, &post_temp_dst, &post_temp_src);
       // add mutable inputs to post temp list
       for (const auto idx : mutate_idx) {
-        if (in_temp_idx_map.find(idx) != in_temp_idx_map.end()) {
-          post_temp_src.push_back(pre_temp_dst[in_temp_idx_map[idx]]);
+        auto map_iter = in_temp_idx_map.find(idx);
+        if (map_iter != in_temp_idx_map.end()) {
+          post_temp_src.push_back(pre_temp_dst[map_iter->second]);
           post_temp_dst.push_back(ndinputs[idx]);
         }
       }
@@ -418,7 +419,6 @@ void PushOperator(const OpStatePtr& state,
           CastNonDefaultStorage<gpu>(pre_temp_src, pre_temp_dst, opctx);
           fcompute(state, opctx, input_blobs, req, output_blobs);
           CastNonDefaultStorage<gpu>(temp_out_dst, post_temp_dst, opctx);
->>>>>>> include mutatable inputs in storage fallback. refactor executor
 #else
           LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -223,7 +223,7 @@ void SetShapeType(const nnvm::Op* op,
 void SetDependency(std::vector<engine::VarHandle> *p_read_vars,
                    std::vector<engine::VarHandle> *p_write_vars,
                    std::vector<Resource> *p_requested,
-                   std::vector<uint32_t> *p_auxidx,
+                   std::vector<uint32_t> *p_mutate_idx,
                    const nnvm::Op* op,
                    const nnvm::NodeAttrs& attrs,
                    const Context& ctx,
@@ -235,7 +235,7 @@ void SetDependency(std::vector<engine::VarHandle> *p_read_vars,
   std::vector<engine::VarHandle>& read_vars  = *p_read_vars;
   std::vector<engine::VarHandle>& write_vars = *p_write_vars;
   std::vector<Resource>& requested = *p_requested;
-  std::vector<uint32_t>& auxidx = *p_auxidx;
+  std::vector<uint32_t>& mutate_idx = *p_mutate_idx;
 
   if (tmp_resource.count(op)) {
     int ntmp = 0;
@@ -261,9 +261,9 @@ void SetDependency(std::vector<engine::VarHandle> *p_read_vars,
     write_vars.push_back(i.var());
   }
   if (mutate.count(op)) {
-    auxidx = mutate[op](attrs);
-    std::sort(auxidx.begin(), auxidx.end());
-    for (auto & i : auxidx) {
+    mutate_idx = mutate[op](attrs);
+    std::sort(mutate_idx.begin(), mutate_idx.end());
+    for (auto & i : mutate_idx) {
       write_vars.push_back(ndinputs[i].var());
     }
   }
@@ -293,36 +293,48 @@ void PushFCompute(const FCompute& fn,
                   const std::vector<engine::VarHandle>& write_vars,
                   const std::vector<Resource>& requested,
                   const std::vector<NDArray>& ndinputs,
-                  const std::vector<NDArray>& ndoutputs) {
+                  const std::vector<NDArray>& ndoutputs,
+                  const std::vector<uint32_t>& mutate_idx) {
   using namespace common;
   bool is_train = AutogradRuntime::Get()->IsTraining();
   Engine::Get()->PushAsync(
-    [ctx, attrs, fn, ndinputs, ndoutputs, requested, is_train](
+    [ctx, attrs, fn, ndinputs, ndoutputs, requested, is_train, mutate_idx](
         RunContext rctx,
         engine::CallbackOnComplete on_complete) {
       std::vector<TBlob> input_blobs, output_blobs;
-      std::vector<NDArray> temp_in_src, temp_in_dst, temp_out_src, temp_out_dst;
+      // pre-fcompute and post-fcompute storage fallback src NDArrays and dst NDArrays
+      std::vector<NDArray> pre_temp_src, pre_temp_dst, post_temp_dst, post_temp_src;
+      // mapping from index in input_blobs to index in pre_temp_dst
+      std::unordered_map<uint32_t, uint32_t> in_temp_idx_map;
+      // populate input blobs and output blobs
+      SetupDefaultBlobs(ndinputs, &input_blobs, &pre_temp_src, &pre_temp_dst, &in_temp_idx_map);
+      SetupDefaultBlobs(ndoutputs, &output_blobs, &post_temp_dst, &post_temp_src);
+      // add mutable inputs to post temp list
+      for (const auto idx : mutate_idx) {
+        if (in_temp_idx_map.find(idx) != in_temp_idx_map.end()) {
+          post_temp_src.push_back(pre_temp_dst[in_temp_idx_map[idx]]);
+          post_temp_dst.push_back(ndinputs[idx]);
+        }
+      }
       OpContext opctx{is_train, rctx,
                       engine::CallbackOnComplete(),
                       requested};
-      GetDefaultBlobs(ndinputs, &input_blobs, &temp_in_src, &temp_in_dst);
-      GetDefaultBlobs(ndoutputs, &output_blobs, &temp_out_src, &temp_out_dst);
       std::vector<OpReqType> req(output_blobs.size(), kWriteTo);
       if (ctx.dev_mask() == gpu::kDevMask) {
 #if MXNET_USE_CUDA
-        CastNonDefaultStorage<gpu>(temp_in_src, temp_in_dst, opctx);
+        CastNonDefaultStorage<gpu>(pre_temp_src, pre_temp_dst, opctx);
         fn(attrs, opctx, input_blobs, req, output_blobs);
         // cast to original storage type, if necessary
-        CastNonDefaultStorage<gpu>(temp_out_dst, temp_out_src, opctx);
+        CastNonDefaultStorage<gpu>(post_temp_src, post_temp_dst, opctx);
         rctx.get_stream<gpu>()->Wait();
 #else
         LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif
       } else {
-        CastNonDefaultStorage<cpu>(temp_in_src, temp_in_dst, opctx);
+        CastNonDefaultStorage<cpu>(pre_temp_src, pre_temp_dst, opctx);
         fn(attrs, opctx, input_blobs, req, output_blobs);
         // cast to original storage type, if necessary
-        CastNonDefaultStorage<cpu>(temp_out_dst, temp_out_src, opctx);
+        CastNonDefaultStorage<cpu>(post_temp_src, post_temp_dst, opctx);
       }
       on_complete();
     }, ctx, read_vars, write_vars, FnProperty::kNormal,
@@ -365,7 +377,8 @@ void PushOperator(const OpStatePtr& state,
                   const std::vector<engine::VarHandle>& write_vars,
                   const std::vector<Resource>& requested,
                   const std::vector<NDArray>& ndinputs,
-                  const std::vector<NDArray>& ndoutputs) {
+                  const std::vector<NDArray>& ndoutputs,
+                  const std::vector<uint32_t>& mutate_idx) {
   using namespace common;
   static auto& fexec_type = nnvm::Op::GetAttr<FExecType>("FExecType");
 
@@ -379,28 +392,40 @@ void PushOperator(const OpStatePtr& state,
   if (fcompute != nullptr) {
     CHECK(exec_type == ExecType::kSync || exec_type == ExecType::kAsync);
     Engine::Get()->PushAsync(
-      [state, fcompute, ndinputs, ndoutputs, requested, is_train, exec_type](
+      [state, fcompute, ndinputs, ndoutputs, requested, is_train, exec_type, mutate_idx](
           RunContext rctx,
           engine::CallbackOnComplete on_complete) {
         OpContext opctx{is_train, rctx, on_complete, requested};
 
         std::vector<TBlob> input_blobs, output_blobs;
-        std::vector<NDArray> temp_in_src, temp_in_dst, temp_out_src, temp_out_dst;
-        GetDefaultBlobs(ndinputs, &input_blobs, &temp_in_src, &temp_in_dst);
-        GetDefaultBlobs(ndoutputs, &output_blobs, &temp_out_src, &temp_out_dst);
+        // pre-fcompute and post-fcompute storage fallback src NDArrays and dst NDArrays
+        std::vector<NDArray> pre_temp_src, pre_temp_dst, post_temp_dst, post_temp_src;
+        // mapping from index in input_blobs to index in pre_temp_dst
+        std::unordered_map<uint32_t, uint32_t> in_temp_idx_map;
+        // populate input blobs and output blobs
+        SetupDefaultBlobs(ndinputs, &input_blobs, &pre_temp_src, &pre_temp_dst, &in_temp_idx_map);
+        SetupDefaultBlobs(ndoutputs, &output_blobs, &post_temp_dst, &post_temp_src);
+        // add mutable inputs to post temp list
+        for (const auto idx : mutate_idx) {
+          if (in_temp_idx_map.find(idx) != in_temp_idx_map.end()) {
+            post_temp_src.push_back(pre_temp_dst[in_temp_idx_map[idx]]);
+            post_temp_dst.push_back(ndinputs[idx]);
+          }
+        }
         std::vector<OpReqType> req(output_blobs.size(), kWriteTo);
         if (rctx.get_ctx().dev_mask() == gpu::kDevMask) {
 #if MXNET_USE_CUDA
-          CastNonDefaultStorage<gpu>(temp_in_src, temp_in_dst, opctx);
+          CastNonDefaultStorage<gpu>(pre_temp_src, pre_temp_dst, opctx);
           fcompute(state, opctx, input_blobs, req, output_blobs);
-          CastNonDefaultStorage<gpu>(temp_out_dst, temp_out_src, opctx);
+          CastNonDefaultStorage<gpu>(temp_out_dst, post_temp_dst, opctx);
+>>>>>>> include mutatable inputs in storage fallback. refactor executor
 #else
           LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif
         } else {
-          CastNonDefaultStorage<cpu>(temp_in_src, temp_in_dst, opctx);
+          CastNonDefaultStorage<cpu>(pre_temp_src, pre_temp_dst, opctx);
           fcompute(state, opctx, input_blobs, req, output_blobs);
-          CastNonDefaultStorage<cpu>(temp_out_dst, temp_out_src, opctx);
+          CastNonDefaultStorage<cpu>(post_temp_src, post_temp_dst, opctx);
         }
         if (exec_type == ExecType::kSync) {
           if (rctx.get_ctx().dev_mask() == gpu::kDevMask) {
@@ -463,8 +488,8 @@ void ImperativeInvokeImpl(const Context& default_ctx,
 
     std::vector<engine::VarHandle> read_vars, write_vars;
     std::vector<Resource> requested;
-    std::vector<uint32_t> auxidx;
-    SetDependency(&read_vars, &write_vars, &requested, &auxidx,
+    std::vector<uint32_t> mutate_idx;
+    SetDependency(&read_vars, &write_vars, &requested, &mutate_idx,
         op, attrs, ctx, ndinputs, ndoutputs);
 
     FCompute fn = common::GetFCompute<FCompute>(op, "FCompute", ctx);
@@ -482,7 +507,7 @@ void ImperativeInvokeImpl(const Context& default_ctx,
             attrs, &ndinputs, &ndoutputs);
       }
       PushFCompute(fn, op, attrs, ctx, read_vars, write_vars,
-          requested, ndinputs, ndoutputs);
+          requested, ndinputs, ndoutputs, mutate_idx);
     } else if (createop.count(op)) {
       auto state =
           createop[op](attrs, ctx, ret->arg_shapes, ret->arg_types);
@@ -492,7 +517,7 @@ void ImperativeInvokeImpl(const Context& default_ctx,
       }
       write_vars.push_back(state.get_var());
       PushOperator(state, op, attrs, ctx, read_vars, write_vars,
-          requested, ndinputs, ndoutputs);
+          requested, ndinputs, ndoutputs, mutate_idx);
     } else {
       LOG(FATAL)
         << "Operator " << op->name << " is not implemented for "

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -25,6 +25,7 @@ namespace exec {
 
 // abstract OpExecutor which provides storage fallback procedure on
 // non-default inputs and outputs
+// FComputeExecutor and FStatefulComputeExecutor inherit from this class
 class StorageFallbackOpExecutor : public OpExecutor {
  public:
   explicit StorageFallbackOpExecutor(const std::vector<uint32_t> &mutate_idx)
@@ -39,8 +40,9 @@ class StorageFallbackOpExecutor : public OpExecutor {
     SetupDefaultBlobs(in_array, &in_data_, &pre_temp_src_, &pre_temp_dst_, &in_temp_idx_map_);
     SetupDefaultBlobs(out_array, &out_data_, &post_temp_dst_, &post_temp_src_);
     for (const auto idx : mutate_idx_) {
-      if (in_temp_idx_map_.find(idx) != in_temp_idx_map_.end()) {
-        post_temp_src_.push_back(pre_temp_dst_[in_temp_idx_map_[idx]]);
+      auto map_iter = in_temp_idx_map_.find(idx);
+      if (map_iter != in_temp_idx_map_.end()) {
+        post_temp_src_.push_back(pre_temp_dst_[map_iter->second]);
         post_temp_dst_.push_back(in_array[idx]);
       }
     }

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -23,40 +23,83 @@ const OperatorProperty* OpPropGetOpProperty(const NodeAttrs& attrs);
 
 namespace exec {
 
-// stateful compute executor
-class StatefulComputeExecutor : public OpExecutor {
+// abstract OpExecutor which provides storage fallback procedure on
+// non-default inputs and outputs
+class StorageFallbackOpExecutor : public OpExecutor {
  public:
-  void Run(RunContext rctx, bool is_gpu) override {
-    using namespace common;
-    op_ctx.run_ctx = rctx;
-    if (is_gpu) {
-#if MXNET_USE_CUDA
-      CastNonDefaultStorage<gpu>(temp_in_src_, temp_in_dst_, op_ctx);
-      CastNonDefaultStorage<gpu>(temp_out_src_, temp_out_dst_, op_ctx);
-      fcompute_(state_, op_ctx, in_data_, req, out_data_);
-      CastNonDefaultStorage<gpu>(temp_out_dst_, temp_out_src_, op_ctx);
-#else
-      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
-#endif
-    } else {
-      CastNonDefaultStorage<cpu>(temp_in_src_, temp_in_dst_, op_ctx);
-      CastNonDefaultStorage<cpu>(temp_out_src_, temp_out_dst_, op_ctx);
-      fcompute_(state_, op_ctx, in_data_, req, out_data_);
-      CastNonDefaultStorage<cpu>(temp_out_dst_, temp_out_src_, op_ctx);
-    }
-#if MKL_EXPERIMENTAL == 1
-    mkl_tblobs_prv_to_cpu(in_data_);
-    mkl_tblobs_prv_to_cpu(out_data_);
-#endif
-  }
+  explicit StorageFallbackOpExecutor(const std::vector<uint32_t> &mutate_idx)
+      : mutate_idx_(mutate_idx) {}
 
   void Setup() override {
     using namespace common;
     in_data_.clear(); out_data_.clear();
-    temp_in_src_.clear(); temp_in_dst_.clear();
-    temp_out_src_.clear(); temp_out_dst_.clear();
-    GetDefaultBlobs(in_array, &in_data_, &temp_in_src_, &temp_in_dst_);
-    GetDefaultBlobs(out_array, &out_data_, &temp_out_src_, &temp_out_dst_);
+    pre_temp_src_.clear(); pre_temp_dst_.clear();
+    post_temp_src_.clear(); post_temp_dst_.clear();
+    in_temp_idx_map_.clear();
+    SetupDefaultBlobs(in_array, &in_data_, &pre_temp_src_, &pre_temp_dst_, &in_temp_idx_map_);
+    SetupDefaultBlobs(out_array, &out_data_, &post_temp_dst_, &post_temp_src_);
+    for (const auto idx : mutate_idx_) {
+      if (in_temp_idx_map_.find(idx) != in_temp_idx_map_.end()) {
+        post_temp_src_.push_back(pre_temp_dst_[in_temp_idx_map_[idx]]);
+        post_temp_dst_.push_back(in_array[idx]);
+      }
+    }
+  }
+
+ protected:
+  // storage fallback before fcompute is launched
+  void PreFCompute(bool is_gpu) {
+    using namespace common;
+    if (is_gpu) {
+#if MXNET_USE_CUDA
+      CastNonDefaultStorage<gpu>(pre_temp_src_, pre_temp_dst_, op_ctx);
+#else
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+#endif
+    } else {
+      CastNonDefaultStorage<cpu>(pre_temp_src_, pre_temp_dst_, op_ctx);
+    }
+  }
+
+  // storage fallback after fcompute is completed
+  void PostFCompute(bool is_gpu) {
+    using namespace common;
+    if (is_gpu) {
+#if MXNET_USE_CUDA
+      CastNonDefaultStorage<gpu>(post_temp_src_, post_temp_dst_, op_ctx);
+#else
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+#endif
+    } else {
+      CastNonDefaultStorage<cpu>(post_temp_src_, post_temp_dst_, op_ctx);
+    }
+  }
+
+  // default storage tensor blobs for fcompute
+  std::vector<TBlob> in_data_, out_data_;
+  // source NDArray for cast storage
+  std::vector<NDArray> pre_temp_src_, post_temp_src_;
+  // destination NDArray for cast storage
+  std::vector<NDArray> pre_temp_dst_, post_temp_dst_;
+  // mapping from index in input_blobs to index in pre_temp_dst
+  std::unordered_map<uint32_t, uint32_t> in_temp_idx_map_;
+  // indices of mutatable inputs
+  std::vector<uint32_t> mutate_idx_;
+};
+
+
+// stateful compute executor
+class StatefulComputeExecutor : public StorageFallbackOpExecutor {
+ public:
+  void Run(RunContext rctx, bool is_gpu) override {
+    op_ctx.run_ctx = rctx;
+    PreFCompute(is_gpu);
+    fcompute_(state_, op_ctx, in_data_, req, out_data_);
+    PostFCompute(is_gpu);
+#if MKL_EXPERIMENTAL == 1
+    mkl_tblobs_prv_to_cpu(in_data_);
+    mkl_tblobs_prv_to_cpu(out_data_);
+#endif
   }
 
   ExecType exec_type() const override {
@@ -69,16 +112,16 @@ class StatefulComputeExecutor : public OpExecutor {
 
   explicit StatefulComputeExecutor(const OpStatePtr& state,
                                    const FStatefulCompute& fcompute,
-                                   ExecType exec_type)
-      : state_(state), fcompute_(fcompute), exec_type_(exec_type) {}
+                                   ExecType exec_type,
+                                   const std::vector<uint32_t> &mutate_idx)
+      : StorageFallbackOpExecutor(mutate_idx),
+        state_(state), fcompute_(fcompute), exec_type_(exec_type) {}
 
  private:
   friend Graph AttachOpExecs(Graph g);
   OpStatePtr state_;
   FStatefulCompute fcompute_;
   ExecType exec_type_;
-  std::vector<TBlob> in_data_, out_data_;
-  std::vector<NDArray> temp_in_src_, temp_in_dst_, temp_out_src_, temp_out_dst_;
 };
 
 
@@ -114,40 +157,18 @@ class StatefulComputeExExecutor : public OpExecutor {
 
 
 // fcompute executor
-class FComputeExecutor : public OpExecutor {
+class FComputeExecutor : public StorageFallbackOpExecutor {
  public:
   void Run(RunContext rctx, bool is_gpu) override {
     using namespace common;
-    // TODO(haibin) avoid repeating this if all inputs are already in default-storage
     op_ctx.run_ctx = rctx;
-    if (is_gpu) {
-#if MXNET_USE_CUDA
-      CastNonDefaultStorage<gpu>(temp_in_src_, temp_in_dst_, op_ctx);
-      CastNonDefaultStorage<gpu>(temp_out_src_, temp_out_dst_, op_ctx);
-      fcompute_(attrs_, op_ctx, in_data_, req, out_data_);
-      CastNonDefaultStorage<gpu>(temp_out_dst_, temp_out_src_, op_ctx);
-#else
-      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
-#endif
-    } else {
-      CastNonDefaultStorage<cpu>(temp_in_src_, temp_in_dst_, op_ctx);
-      CastNonDefaultStorage<cpu>(temp_out_src_, temp_out_dst_, op_ctx);
-      fcompute_(attrs_, op_ctx, in_data_, req, out_data_);
-      CastNonDefaultStorage<cpu>(temp_out_dst_, temp_out_src_, op_ctx);
-    }
+    PreFCompute(is_gpu);
+    fcompute_(attrs_, op_ctx, in_data_, req, out_data_);
+    PostFCompute(is_gpu);
 #if MKL_EXPERIMENTAL == 1
     mkl_tblobs_prv_to_cpu(in_data_);
     mkl_tblobs_prv_to_cpu(out_data_);
 #endif
-  }
-
-  void Setup() override {
-    using namespace common;
-    in_data_.clear(); out_data_.clear();
-    temp_in_src_.clear(); temp_in_dst_.clear();
-    temp_out_src_.clear(); temp_out_dst_.clear();
-    GetDefaultBlobs(in_array, &in_data_, &temp_in_src_, &temp_in_dst_);
-    GetDefaultBlobs(out_array, &out_data_, &temp_out_src_, &temp_out_dst_);
   }
 
   ExecType exec_type() const override {
@@ -155,16 +176,15 @@ class FComputeExecutor : public OpExecutor {
   }
 
   explicit FComputeExecutor(const NodeAttrs& attrs, FCompute fcompute,
-                            ExecType exec_type)
-      : attrs_(attrs), fcompute_(fcompute), exec_type_(exec_type) {
+                            ExecType exec_type, const std::vector<uint32_t> &mutate_idx)
+      : StorageFallbackOpExecutor(mutate_idx),
+        attrs_(attrs), fcompute_(fcompute), exec_type_(exec_type) {
   }
 
  private:
   NodeAttrs attrs_;
   FCompute fcompute_;
   ExecType exec_type_;
-  std::vector<TBlob> in_data_, out_data_;
-  std::vector<NDArray> temp_in_src_, temp_in_dst_, temp_out_src_, temp_out_dst_;
 };
 
 // fcompute_ex executor
@@ -247,7 +267,8 @@ Graph AttachOpExecs(Graph g) {
       FStatefulCompute fcompute = common::GetFCompute<FStatefulCompute>(
           op, "FStatefulCompute", vctx[i]);
       if (fcompute != nullptr) {
-        ret[i] = std::make_shared<StatefulComputeExecutor>(state, fcompute, exec_type);
+        ret[i] = std::make_shared<StatefulComputeExecutor>(state, fcompute,
+                                                           exec_type, mutate_index);
       } else {
         FStatefulComputeEx fcompute_ex = common::GetFCompute<FStatefulComputeEx>(
             op, "FStatefulComputeEx", vctx[i]);
@@ -266,7 +287,7 @@ Graph AttachOpExecs(Graph g) {
       if (fcompute != nullptr) {
         ret[i] = std::make_shared<StatefulComputeExecutor>(
             dynamic_cast<StatefulComputeExecutor*>(ret[fwd_id].get())->state_,
-            fcompute, exec_type);
+            fcompute, exec_type, mutate_index);
       } else {
         FStatefulComputeEx fcompute_ex = common::GetFCompute<FStatefulComputeEx>(
             op, "FStatefulComputeEx", vctx[i]);
@@ -285,7 +306,7 @@ Graph AttachOpExecs(Graph g) {
             inode.source->attrs, fcomp_ex, exec_type);
       } else if (fcompute != nullptr) {
         ret[i] = std::make_shared<FComputeExecutor>(
-            inode.source->attrs, fcompute, exec_type);
+            inode.source->attrs, fcompute, exec_type, mutate_index);
       } else {
         LOG(INFO) << "Neither FCompute nor FComputeEx registered " << op->name;
       }

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -360,8 +360,8 @@ void FCompExFallback(const nnvm::NodeAttrs& attrs,
   using namespace mxnet::common;
   std::vector<TBlob> in_blobs, out_blobs;
   std::vector<NDArray> temp_in_src, temp_in_dst, temp_out_src, temp_out_dst;
-  GetDefaultBlobs(inputs, &in_blobs, &temp_in_src, &temp_in_dst);
-  GetDefaultBlobs(outputs, &out_blobs, &temp_out_src, &temp_out_dst);
+  SetupDefaultBlobs(inputs, &in_blobs, &temp_in_src, &temp_in_dst);
+  SetupDefaultBlobs(outputs, &out_blobs, &temp_out_src, &temp_out_dst);
   CastNonDefaultStorage<xpu>(temp_in_src, temp_in_dst, ctx, true);
   fcompute(attrs, ctx, in_blobs, req, out_blobs);
   CastNonDefaultStorage<xpu>(temp_out_dst, temp_out_src, ctx, true);

--- a/tests/cpp/operator/ndarray_test.cc
+++ b/tests/cpp/operator/ndarray_test.cc
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) 2017 by Contributors
- * \file ndarray_test.cc
- * \brief ndarray unit test utility functions
- * \author Haibin Lin
-*/

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -358,6 +358,7 @@ def test_adam():
               {'rescale_grad': 0.8, 'wd': 0.05}]
     for kwarg in kwargs:
         compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, np.float32)
+        compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, np.float32, g_stype='row_sparse')
 
 # RMSProp
 class PyRMSProp(mx.optimizer.Optimizer):
@@ -498,6 +499,7 @@ def test_rms():
               {'rescale_grad': 0.8, 'wd': 0.05, 'centered': True, 'clip_weights': 0.01}]
     for kwarg in kwargs:
         compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, np.float32)
+        compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, np.float32, g_stype='row_sparse')
 
 if __name__ == '__main__':
     test_adam()


### PR DESCRIPTION
- mutable inputs are converted back to sparse after fcompute, for both imperative and symbolic execution
- refactored fallback logic in attach_op_exec_pass and let dense operator inherit from storage_fallback_executor
- fixed the bug where fstateful comp executor overrides input tblobs during backward initialization. This is not desired since both forward and backward executor will perform fallback on sparse inputs, and the tblobs are different.
- added more fallback test with optimizers
- removed `ndarray_test.cc` since it's empty in this PR @cjolivier01
- known issue with BatchNorm https://github.com/apache/incubator-mxnet/issues/7346

@piiswrong @reminisce 