### PR TITLE
kvstore.row_sparse_pull for GPU and end-to-end benchmark: CPU vs. multi-GPUs

### DIFF
--- a/benchmark/python/sparse_end2end.py
+++ b/benchmark/python/sparse_end2end.py
@@ -1,0 +1,213 @@
+from mxnet.test_utils import *
+import time
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description="Run sparse linear regression " \
+                                             "with distributed kvstore",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('--profiler', type=int, default=0,
+                    help='whether to use profiler')
+parser.add_argument('--num-epoch', type=int, default=1,
+                    help='number of epochs to train')
+parser.add_argument('--batch-size', type=int, default=512,
+                    help='number of examples per batch')
+parser.add_argument('--num-batch', type=int, default=99999999,
+                    help='number of batches per epoch')
+parser.add_argument('--dummy-iter', type=int, default=0,
+                    help='whether to use dummy iterator to exclude io cost')
+parser.add_argument('--kvstore', type=str, default='local',
+                    help='what kvstore to use [local, dist_sync, etc]')
+parser.add_argument('--log-level', type=str, default='debug',
+                    help='logging level [debug, info, error]')
+parser.add_argument('--dataset', type=str, default='avazu',
+                    help='what test dataset to use')
+parser.add_argument('--num-gpu', type=int, default=0,
+                    help='number of gpus to use. 0 means using cpu(0);'
+                         'otherwise, use gpu(0),...,gpu(num_gpu-1)')
+parser.add_argument('--output-dim', type=int, default=1,
+                    help='number of columns of the forward output')
+
+
+def get_libsvm_data(data_dir, data_name, url, data_origin_name):
+    if not os.path.isdir(data_dir):
+        os.system("mkdir " + data_dir)
+    os.chdir(data_dir)
+    if (not os.path.exists(data_name)):
+        import urllib
+        zippath = os.path.join(data_dir, data_origin_name)
+        urllib.urlretrieve(url, zippath)
+        os.system("bzip2 -d %r" % data_origin_name)
+    os.chdir("..")
+
+
+class DummyIter(mx.io.DataIter):
+    "A dummy iterator that always return the same batch, used for speed testing"
+    def __init__(self, real_iter):
+        super(DummyIter, self).__init__()
+        self.real_iter = real_iter
+        self.provide_data = real_iter.provide_data
+        self.provide_label = real_iter.provide_label
+        self.batch_size = real_iter.batch_size
+
+        for batch in real_iter:
+            self.the_batch = batch
+            break
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        return self.the_batch
+
+# testing dataset sources
+avazu = {
+    'data_name': 'avazu-app.t',
+    'data_origin_name': 'avazu-app.t.bz2',
+    'url': "https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/avazu-app.t.bz2",
+    'feature_dim': 1000000,
+}
+
+kdda = {
+    'data_name': 'kdda.t',
+    'data_origin_name': 'kdda.t.bz2',
+    'url': "https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/kdda.t.bz2",
+    'feature_dim': 20216830,
+}
+
+datasets = { 'kdda' : kdda, 'avazu' : avazu }
+
+
+def get_sym(feature_dim):
+     initializer = mx.initializer.Normal()
+     x = mx.symbol.Variable("data", stype='csr')
+     norm_init = mx.initializer.Normal(sigma=0.01)
+     w = mx.symbol.Variable("w", shape=(feature_dim, args.output_dim), init=norm_init, stype='row_sparse')
+     embed = mx.symbol.dot(x, w)
+     y = mx.symbol.Variable("softmax_label")
+     model = mx.symbol.SoftmaxOutput(data=embed, label=y, name="out")
+     return model
+
+
+if __name__ == '__main__':
+
+    # arg parser
+    args = parser.parse_args()
+    num_epoch = args.num_epoch
+    num_batch = args.num_batch
+    kvstore = args.kvstore
+    profiler = args.profiler > 0
+    batch_size = args.batch_size
+    dummy_iter = args.dummy_iter
+    dataset = args.dataset
+    log_level = args.log_level
+    contexts = mx.context.cpu(0) if args.num_gpu < 1\
+        else [mx.context.gpu(i) for i in range(args.num_gpu)]
+
+    # create kvstore when there are gpus
+    kv = mx.kvstore.create(kvstore) if args.num_gpu >= 1 else None
+    rank = kv.rank if kv is not None else 0
+    num_worker = kv.num_workers if kv is not None else 1
+
+    # only print log for rank 0 worker
+    import logging
+    if rank != 0:
+        log_level = logging.ERROR
+    elif log_level == 'DEBUG':
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    head = '%(asctime)-15s %(message)s'
+    logging.basicConfig(level=log_level, format=head)
+
+    # dataset
+    assert(dataset in datasets), "unknown dataset " + dataset
+    metadata = datasets[dataset]
+    feature_dim = metadata['feature_dim']
+    if logging:
+        logging.debug('preparing data ... ')
+    data_dir = os.path.join(os.getcwd(), 'data')
+    path = os.path.join(data_dir, metadata['data_name'])
+    if not os.path.exists(path):
+        get_libsvm_data(data_dir, metadata['data_name'], metadata['url'],
+                        metadata['data_origin_name'])
+        assert os.path.exists(path)
+
+    # data iterator
+    train_data = mx.io.LibSVMIter(data_libsvm=path, data_shape=(feature_dim,),
+                                  batch_size=batch_size, num_parts=num_worker,
+                                  part_index=rank)
+    if dummy_iter:
+        train_data = DummyIter(train_data)
+
+    # model
+    model = get_sym(feature_dim)
+
+    # module
+    mod = mx.mod.Module(symbol=model, data_names=['data'],
+                        label_names=['softmax_label'], context=contexts)
+    mod.bind(data_shapes=train_data.provide_data, label_shapes=train_data.provide_label)
+    mod.init_params(initializer=mx.init.Uniform(scale=.1))
+    sgd = mx.optimizer.SGD(momentum=0.0, clip_gradient=5.0,
+                           learning_rate=0.1, rescale_grad=1.0/batch_size/num_worker)
+    mod.init_optimizer(optimizer=sgd, kvstore=kv)
+    # use accuracy as the metric
+    metric = mx.metric.create('MSE')
+
+    index = mod._exec_group.param_names.index('w')
+    # weight_array bound to executors of the contexts
+    weight_array = mod._exec_group.param_arrays[index]
+
+    # start profiler
+    if profiler:
+        import random
+        name = 'profile_output_' + str(num_worker) + '.json'
+        mx.profiler.profiler_set_config(mode='all', filename=name)
+        mx.profiler.profiler_set_state('run')
+
+    logging.debug('start training ...')
+    start = time.time()
+    data_iter = iter(train_data)
+    for epoch in range(num_epoch):
+        nbatch = 0
+        end_of_batch = False
+        data_iter.reset()
+        metric.reset()
+        next_batch = next(data_iter)
+        while not end_of_batch:
+            nbatch += 1
+            batch = next_batch
+
+            mod.forward_backward(batch)
+            # update parameters
+            mod.update()
+            # if have kvstore, need to pull corresponding rows of
+            # the weights to each context
+            if kv is not None:
+                # column indices (NDArray type) of the csr data
+                # used as the row_idx of the weight row-sparse matrix
+                # TODO(junwu):
+                # the following two lines block, may need to precompute
+                # them and cache them outside the for loop
+                row_indices = batch.data[0].indices
+                indptr = batch.data[0].indptr.asnumpy()
+                row_idx_array = []
+                for s in mod._exec_group.slices:
+                    row_idx_array.append(row_indices[indptr[s.start]:indptr[s.stop]])
+                kv.row_sparse_pull('w', weight_array, priority=-index, row_ids=row_idx_array)
+
+            try:
+                # pre fetch next batch
+                next_batch = next(data_iter)
+                if nbatch == num_batch:
+                    raise StopIteration
+            except StopIteration:
+                end_of_batch = True
+            # accumulate prediction accuracy
+            mod.update_metric(metric, batch.label)
+        logging.info('epoch %d, %s' % (epoch, metric.get()))
+    if profiler:
+        mx.profiler.profiler_set_state('stop')
+    end = time.time()
+    time_cost = end - start
+    logging.info('num_worker = ' + str(num_worker) + ', time cost = ' + str(time_cost))

--- a/benchmark/python/sparse_end2end.py
+++ b/benchmark/python/sparse_end2end.py
@@ -25,7 +25,7 @@ parser.add_argument('--dataset', type=str, default='avazu',
 parser.add_argument('--num-gpu', type=int, default=0,
                     help='number of gpus to use. 0 means using cpu(0);'
                          'otherwise, use gpu(0),...,gpu(num_gpu-1)')
-parser.add_argument('--output-dim', type=int, default=1,
+parser.add_argument('--output-dim', type=int, default=4,
                     help='number of columns of the forward output')
 
 
@@ -178,9 +178,6 @@ if __name__ == '__main__':
             nbatch += 1
             batch = next_batch
 
-            mod.forward_backward(batch)
-            # update parameters
-            mod.update()
             # if have kvstore, need to pull corresponding rows of
             # the weights to each context
             if kv is not None:
@@ -195,6 +192,10 @@ if __name__ == '__main__':
                 for s in mod._exec_group.slices:
                     row_idx_array.append(row_indices[indptr[s.start]:indptr[s.stop]])
                 kv.row_sparse_pull('w', weight_array, priority=-index, row_ids=row_idx_array)
+
+            mod.forward_backward(batch)
+            # update parameters
+            mod.update()
 
             try:
                 # pre fetch next batch

--- a/benchmark/python/sparse_end2end.py
+++ b/benchmark/python/sparse_end2end.py
@@ -167,7 +167,7 @@ if __name__ == '__main__':
                            learning_rate=0.1, rescale_grad=1.0/batch_size/num_worker)
     mod.init_optimizer(optimizer=sgd, kvstore=kv)
     # use accuracy as the metric
-    metric = mx.metric.create('MSE')
+    metric = mx.metric.create('acc')
 
     index = mod._exec_group.param_names.index('w')
     # weight_array bound to executors of the contexts

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -226,6 +226,12 @@ class NDArray {
     return ptr_->aux_shapes;
   }
 
+  /*! returns the dtypes of all aux data */
+  const std::vector<int>& aux_types() const {
+    CHECK(storage_type() != kDefaultStorage);
+    return ptr_->aux_types;
+  }
+
   /*!
    * \brief For a sparse operation on a csr matrix for example,
    * the size of the column index array

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -1151,7 +1151,9 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
       CHECK_LE(nword, std::numeric_limits<nnvm::dim_t>::max());
       // allocate float arrays
       TShape shape{static_cast<nnvm::dim_t>(nword)};
-      NDArray nd(shape, ctx);
+      // TODO(junwu): adding delay_alloc=true to create nd
+      // is a temporary solution.
+      NDArray nd(shape, ctx, true);
       data_pool_[i] = nd;
       // put the new allocated arrays to shared pool
       if (shared_pool != nullptr)  {

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -208,25 +208,92 @@ class CommCPU : public Comm {
         CHECK_EQ(row_id.ctx().dev_mask(), Context::kCPU)
                  << "BroadcastRowSparse with row_indices on gpu context not supported";
         // retain according to unique indices
-        const bool is_to_gpu = out->ctx().dev_mask() == Context::kGPU;
-        NDArray out_cpu = is_to_gpu? NDArray(kRowSparseStorage, src.shape(),
-            src.ctx(), true, src.dtype(), src.aux_types()) : *out;
-        Engine::Get()->PushSync([=](RunContext rctx) {
-            const TBlob& indices = row_id.data();
-            NDArray temp = out_cpu;  // get rid of const qualifier
-            op::SparseRetainOpForwardRspImpl<cpu>(rctx.get_stream<cpu>(),
-                                                  src, indices, kWriteTo,
-                                                  &temp);
-          }, Context::CPU(), {src.var(), row_id.var()}, {out_cpu.var()},
-          FnProperty::kNormal, priority, PROFILER_MESSAGE("KVStoreSparseRetain"));
-        if (is_to_gpu) {
-          CopyFromTo(out_cpu, out, priority);
+        const bool use_sparse_retain = (src.shape()[0] != src.storage_shape()[0])
+          || (row_id.dtype() != out->aux_type(rowsparse::kIdx));
+        if (use_sparse_retain) {  // use sparse_retain op
+          const bool is_to_gpu = out->ctx().dev_mask() == Context::kGPU;
+          NDArray out_cpu = is_to_gpu? NDArray(kRowSparseStorage, src.shape(),
+              src.ctx(), true, src.dtype(), src.aux_types()) : *out;
+          Engine::Get()->PushSync([=](RunContext rctx) {
+              const TBlob& indices = row_id.data();
+              NDArray temp = out_cpu;  // get rid of const qualifier
+              op::SparseRetainOpForwardRspImpl<cpu>(rctx.get_stream<cpu>(),
+                                                    src, indices, kWriteTo,
+                                                    &temp);
+            }, Context::CPU(), {src.var(), row_id.var()}, {out_cpu.var()},
+            FnProperty::kNormal, priority, PROFILER_MESSAGE("KVStoreSparseRetain"));
+          if (is_to_gpu) {
+            CopyFromTo(out_cpu, out, priority);
+          }
+        } else {  // direct copy rows
+          Engine::Get()->PushSync([=](RunContext rctx) {
+              CopyRetainedRowsToGPU(rctx.get_stream<cpu>(), rctx.get_stream<gpu>(),
+                                    src, row_id, out);
+            }, out->ctx(), {src.var(), row_id.var()}, {out->var()},
+            FnProperty::kCopyToGPU, priority, PROFILER_MESSAGE("KVStoreCopyRetainedRowsToGPU"));
         }
       }
     }
   }
 
  private:
+  /*!
+   * \brief When src is a rsp with full rows,
+   * simply copy retained rows directly from cpu to gpu
+   * without invoking sparse_retain op.
+   */
+  void CopyRetainedRowsToGPU(mshadow::Stream<cpu>* cpu_stream,
+                             mshadow::Stream<gpu>* gpu_stream,
+                             const NDArray& src,
+                             const NDArray& indices,
+                             NDArray* dst) {
+#if MXNET_USE_CUDA == 1
+    CHECK_EQ(src.storage_type(), kRowSparseStorage)
+      << "CopyRetainedRowsToGPU expects row-sparse src NDArray";
+    CHECK_EQ(src.ctx().dev_mask(), Context::kCPU)
+      << "CopyRetainedRowsToGPU with src on gpu context not supported";
+    CHECK_EQ(src.storage_shape()[0], src.shape()[0])
+      << "CopyRetainedRowsToGPU only supports src rsp with full rows";
+    CHECK_EQ(indices.storage_type(), kDefaultStorage);
+    CHECK_EQ(indices.ctx().dev_mask(), Context::kCPU);
+    CHECK_EQ(dst->storage_type(), kRowSparseStorage);
+    CHECK_EQ(dst->ctx().dev_mask(), Context::kGPU);
+    CHECK_EQ(indices.dtype(), dst->aux_type(rowsparse::kIdx))
+      << "CopyRetainedRowsToGPU only supports same data type for idx array and dst aux_data(0)";
+    if (!src.storage_initialized() || indices.data().Size() == 0U) {
+      op::FillZerosRspImpl(gpu_stream, dst);
+      return;
+    }
+    using namespace mshadow;
+
+    const TBlob& src_data = src.data();
+    const TBlob& idx_data = indices.data();
+    const size_t row_length = src.shape().ProdShape(1, src.shape().ndim());
+    const size_t num_rows_retained = idx_data.Size();
+    dst->CheckAndAlloc({Shape1(num_rows_retained)});
+    TBlob dst_data = dst->data();
+    TBlob dst_idx_data = dst->aux_data(rowsparse::kIdx);
+    MSHADOW_TYPE_SWITCH(src.dtype(), DType, {
+      MSHADOW_IDX_TYPE_SWITCH(indices.dtype(), IType, {
+        // copy idx array
+        Tensor<gpu, 1, IType> dst_idx_tensor = dst_idx_data.FlatTo1D<gpu, IType>(gpu_stream);
+        const Tensor<cpu, 1, IType> idx_tensor = idx_data.FlatTo1D<cpu, IType>(cpu_stream);
+        Copy(dst_idx_tensor, idx_tensor, gpu_stream);
+        // copy src data
+        const Tensor<cpu, 2, DType> src_data_tensor = src_data.get_with_shape<cpu, 2, DType>(
+            Shape2(src_data.shape_[0], row_length), cpu_stream);
+        Tensor<gpu, 2, DType> dst_data_tensor = dst_data.get_with_shape<gpu, 2, DType>(
+            Shape2(dst_data.shape_[0], row_length), gpu_stream);
+        for (size_t i = 0; i < num_rows_retained; ++i) {
+          Copy(dst_data_tensor[i], src_data_tensor[idx_tensor[i]], gpu_stream);
+        }
+      })
+    })
+#else
+    LOG(FATAL) << "GPU not enabled";
+#endif
+  }
+
   // reduce sum into val[0]
   inline void ReduceSumCPU(const std::vector<NDArray> &in_data) {
     MSHADOW_TYPE_SWITCH(in_data[0].dtype(), DType, {

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -208,7 +208,7 @@ class CommCPU : public Comm {
         CHECK_EQ(row_id.ctx().dev_mask(), Context::kCPU)
                  << "BroadcastRowSparse with row_indices on gpu context not supported";
         // retain according to unique indices
-        bool is_to_gpu = out->ctx().dev_mask() == Context::kGPU;
+        const bool is_to_gpu = out->ctx().dev_mask() == Context::kGPU;
         NDArray out_cpu = is_to_gpu? NDArray(kRowSparseStorage, src.shape(),
             src.ctx(), true, src.dtype(), src.aux_types()) : *out;
         Engine::Get()->PushSync([=](RunContext rctx) {

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -209,7 +209,8 @@ class CommCPU : public Comm {
                  << "BroadcastRowSparse with row_indices on gpu context not supported";
         // retain according to unique indices
         const bool use_sparse_retain = (src.shape()[0] != src.storage_shape()[0])
-          || (row_id.dtype() != out->aux_type(rowsparse::kIdx));
+          || (row_id.dtype() != out->aux_type(rowsparse::kIdx))
+          || (out->ctx().dev_mask() != Context::kGPU);
         if (use_sparse_retain) {  // use sparse_retain op
           const bool is_to_gpu = out->ctx().dev_mask() == Context::kGPU;
           NDArray out_cpu = is_to_gpu? NDArray(kRowSparseStorage, src.shape(),

--- a/src/kvstore/kvstore_local.h
+++ b/src/kvstore/kvstore_local.h
@@ -126,7 +126,7 @@ class KVStoreLocal : public KVStore {
 
   void PullRowSparse(const std::vector<int>& keys,
                      const std::vector<std::pair<NDArray*, NDArray>>& val_rowids,
-                     int priority = 0) {
+                     int priority = 0) override {
     std::vector<int> uniq_keys;
     std::vector<std::vector<std::pair<NDArray*, NDArray>>> grouped_val_rowids;
     GroupKVPairs(keys, val_rowids, &uniq_keys, &grouped_val_rowids);

--- a/tests/python/gpu/test_kvstore_gpu.py
+++ b/tests/python/gpu/test_kvstore_gpu.py
@@ -1,0 +1,51 @@
+# pylint: skip-file
+import mxnet as mx
+import numpy as np
+from mxnet.test_utils import assert_almost_equal, default_context
+
+shape = (4, 4)
+keys = [5, 7, 11]
+str_keys = ['b', 'c', 'd']
+
+
+def init_kv_with_str(stype='default'):
+    """init kv """
+    kv = mx.kv.create()
+    # single
+    kv.init('a', mx.nd.zeros(shape, stype=stype))
+    # list
+    kv.init(str_keys, [mx.nd.zeros(shape=shape, stype=stype)] * len(keys))
+    return kv
+
+
+def test_row_sparse_pull():
+    kv = init_kv_with_str('row_sparse')
+    kv.init('e', mx.nd.ones(shape)._to_rsp())
+
+    def check_row_sparse_pull(kv, count, ctx=default_context()):
+        num_rows = shape[0]
+        vals = []
+        row_ids = []
+        all_row_ids = np.arange(num_rows)
+        for i in range(count):
+            vals.append(mx.nd.zeros(shape, ctx=ctx)._to_rsp())
+            row_id = np.random.randint(num_rows, size=num_rows)
+            row_ids.append(mx.nd.array(row_id, dtype='int64'))
+        row_ids_to_pull = row_ids[0] if len(row_ids) == 1 else row_ids
+        vals_to_pull = vals[0] if len(vals) == 1 else vals
+
+        kv.row_sparse_pull('e', out=vals_to_pull, row_ids=row_ids_to_pull)
+        for val, row_id in zip(vals, row_ids):
+            retained = val.asnumpy()
+            excluded_row_ids = np.setdiff1d(all_row_ids, row_id.asnumpy())
+            for row in range(num_rows):
+                expected_val = np.zeros_like(retained[row])
+                expected_val += 0 if row in excluded_row_ids else 1
+                assert_almost_equal(retained[row], expected_val)
+
+    check_row_sparse_pull(kv, 1, mx.gpu(0))
+    check_row_sparse_pull(kv, 4, mx.gpu(0))
+
+
+if __name__ == '__main__':
+    test_row_sparse_pull()

--- a/tests/python/gpu/test_kvstore_gpu.py
+++ b/tests/python/gpu/test_kvstore_gpu.py
@@ -20,7 +20,7 @@ def init_kv_with_str(stype='default'):
 
 def test_row_sparse_pull():
     kv = init_kv_with_str('row_sparse')
-    kv.init('e', mx.nd.ones(shape)._to_rsp())
+    kv.init('e', mx.nd.ones(shape).tostype('row_sparse'))
 
     def check_row_sparse_pull(kv, count, ctx=default_context()):
         num_rows = shape[0]
@@ -28,7 +28,7 @@ def test_row_sparse_pull():
         row_ids = []
         all_row_ids = np.arange(num_rows)
         for i in range(count):
-            vals.append(mx.nd.zeros(shape, ctx=ctx)._to_rsp())
+            vals.append(mx.nd.zeros(shape, ctx=ctx).tostype('row_sparse'))
             row_id = np.random.randint(num_rows, size=num_rows)
             row_ids.append(mx.nd.array(row_id, dtype='int64'))
         row_ids_to_pull = row_ids[0] if len(row_ids) == 1 else row_ids

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -187,7 +187,7 @@ def test_sparse_slice():
 
 
 def test_sparse_retain():
-    def check_sparse_retain(shape, density):
+    def check_sparse_retain(shape, density, index_type=np.int64):
         num_rows = shape[0]
         rsp, _ = rand_sparse_ndarray(shape=shape, stype='row_sparse', density=density)
         length = np.random.randint(1, num_rows + 1)
@@ -197,7 +197,7 @@ def test_sparse_retain():
         tensor_retained_expected = np.zeros(shape)
         for i in idx:
             tensor_retained_expected[i][:] = dns[i]
-        indices = mx.nd.array(idx)
+        indices = mx.nd.array(idx, dtype=index_type)
         rsp_retained = mx.nd.sparse_retain(rsp, indices=indices)
         assert same(tensor_retained_expected, rsp_retained.asnumpy())
 
@@ -211,9 +211,11 @@ def test_sparse_retain():
     shape = rand_shape_2d()
     shape_3d = rand_shape_3d()
     densities = [0.01, 0.1, 0.2, 0.5, 0.8, 1.0]
+    index_types = [np.float32, np.int32, np.int64]
     for density in densities:
-        check_sparse_retain(shape, density)
-        check_sparse_retain(shape_3d, density)
+        for itype in index_types:
+            check_sparse_retain(shape, density, itype)
+            check_sparse_retain(shape_3d, density, itype)
 
 
 def test_sparse_nd_zeros():


### PR DESCRIPTION
# Overview
1. Extended kvstore.row_sparse_pull to support output arrays on GPUs and added gpu unit test.
2. Added benchmark script for sparse end-to-end flow (modified base on [example/sparse/linear_regression.py](https://github.com/eric-haibin-lin/mxnet/blob/sparse/example/sparse/linear_regression.py)).

@piiswrong @eric-haibin-lin @madjam @stefanhenneking @anirudh2290 @mli

# Bencmark Results
**Hardware**: p2.8xlarge
**Model**:
```python
x = mx.symbol.Variable("data", stype='csr')
norm_init = mx.initializer.Normal(sigma=0.01)
w = mx.symbol.Variable("w", shape=(feature_dim, args.output_dim), init=norm_init, stype='row_sparse')
embed = mx.symbol.dot(x, w)
y = mx.symbol.Variable("softmax_label")
model = mx.symbol.SoftmaxOutput(data=embed, label=y, name="out")
```

**Note**: The CPU benchmark used the MXNet lib compiled **without** `USE_CUDA=1`.
### avazu dataset
**Feature Dim Size**: 1,000,000

| device |  batch size | output dim size | runtime (s) / epoch | device |  batch size | output dim size | runtime (s) / epoch |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| cpu/32 cores | 512 * 1 | 512 | 196 | gpu/1 card | 512 * 64 * 1 | 512 | 24 |
| cpu/32 cores | 512 * 2 | 512 | 109 | gpu/2 cards | 512 * 64 * 2 | 512 | 20 |
| cpu/32 cores | 512 * 4 | 512 | 63 | gpu/3 cards | 512 * 64 * 3 | 512 | 20 |
| cpu/32 cores | 512 * 8 | 512 | 42 | gpu/4 cards | 512 * 64 * 4 | 512 | 20 |
| cpu/32 cores | 512 * 16 | 512 | 30 | gpu/5 cards | 512 * 64 * 5 | 512 | 20 |
| cpu/32 cores | 512 * 32 | 512 | 25 | gpu/6 cards | 512 * 64 * 6 | 512 | 20 |
| cpu/32 cores | 512 * 64 | 512 | 23 | gpu/7 cards | 512 * 64 * 7 | 512 | 20 |
| cpu/32 cores | 512 * 128 | 512 | 22 | gpu/8 cards | 512 * 64 * 8 | 512 | 21 |
| cpu/32 cores | 512 * 1 | 1,024 | 359 | gpu/1 card | 512 * 64 * 1 * 64 | 1,024 | 49 |
| cpu/32 cores | 512 * 2 | 1,024 | 198 | gpu/2 cards | 512 * 64 * 2 * 64 | 1,024 | 41 |
| cpu/32 cores | 512 * 4 | 1,024 | 121 | gpu/3 cards | 512 * 64 * 3 | 1,024 | 39 |
| cpu/32 cores | 512 * 8 | 1,024 | 79 | gpu/4 cards | 512 * 64 * 4| 1,024 | 39 |
| cpu/32 cores | 512 * 16 | 1,024 | 58 | gpu/5 cards | 512 * 64 * 5 | 1,024 | 38 |
| cpu/32 cores | 512 * 32 | 1,024 | 50 | gpu/6 cards | 512 * 64 * 6 | 1,024 | 40 |
| cpu/32 cores | 512 * 64 | 1,024 | 46 | gpu/7 cards | 512 * 64 * 7 | 1,024 | 40 |
| cpu/32 cores | 512 * 128 | 1,024 | 44  | gpu/8 cards | 512 * 64 * 8 | 1,024 | 41 |

### kdda dataset
**Feature Dim Size**: 20,216,830

| device |  batch size | output dim size | runtime (s) / epoch | device |  batch size | output dim size | runtime (s) / epoch |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| cpu/32 cores | 512 * 1 | 32 | 123 | gpu/1 card | 512 * 64 * 1 | 32 | 20 |
| cpu/32 cores | 512 * 2 | 32 | 71 | gpu/2 cards | 512 * 64 *2 | 32 | 20 |
| cpu/32 cores | 512 * 4 | 32 | 46 | gpu/3 cards | 512 * 64 * 3 | 32 | 20 |
| cpu/32 cores | 512 * 8 | 32 | 33 | gpu/4 cards | 512 * 64 * 4| 32 | 20 |
| cpu/32 cores | 512 * 16 | 32 | 27 | gpu/5 cards | 512 * 64 * 5 | 32 | 20 |
| cpu/32 cores | 512 * 32 | 32 | 24 | gpu/6 cards | 512 * 64 * 6 | 32 | 20 |
| cpu/32 cores | 512 * 64 | 32 | 22 | gpu/7 cards | 512 * 64 * 7 | 32 | 20 |
| cpu/32 cores | 512 * 128 | 32 | 21 | gpu/8 cards | 512 * 64 * 8 | 32 | 21 |
| cpu/32 cores | 512 * 1 | 64 | 200 | gpu/1 card | 512 * 64 * 1 | 64 | 40 |
| cpu/32 cores | 512 * 2 | 64 | 120 | gpu/2 cards | 512 * 64 * 2 | 64 | 40 |
| cpu/32 cores | 512 * 4 | 64 | 80 | gpu/3 cards | 512 * 64 * 3 | 64 | 40 |
| cpu/32 cores | 512 * 8 | 64 | 61 | gpu/4 cards | 512 * 64 * 4| 64 | 40 |
| cpu/32 cores | 512 * 16 | 64 | 50 | gpu/5 cards | 512 * 64 * 5 | 64 | 40 |
| cpu/32 cores | 512 * 32 | 64 | 45 | gpu/6 cards | 512 * 64 * 6 | 64 | 40 |
| cpu/32 cores | 512 * 64 | 64 | 43 | gpu/7 cards | 512 * 64 * 7 | 64 | 40 |
| cpu/32 cores | 512 * 128 | 64 | 42 | gpu/8 cards | 512 * 64 * 8 | 64 | 41 |

# Profiling Results
**avazu dataset, batch_size=512, output_dim=1024**

**Profiling 32-core CPU training**
![image](https://user-images.githubusercontent.com/4978794/29202196-7f381cc8-7e1a-11e7-887e-78658bbdbd2c.png)

**Profiling single GPU training**
![image](https://user-images.githubusercontent.com/4978794/29202093-81c7c19c-7e19-11e7-897d-06001c87d140.png)

**Profiling 8-GPU training** Run with env var `MXNET_CPU_WORKER_NTHREADS=8` to parallelize execution of 8 sparse_retain operations.
![image](https://user-images.githubusercontent.com/4978794/29235181-8bdd3fd4-7eb1-11e7-8e4f-71d2d4f53696.png)