### PR TITLE
Elementwise Sum (add_n) for rowsparse on GPU

### DIFF
--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -165,9 +165,11 @@ class CommCPU : public Comm {
       auto result = buf.merged;
       Engine::Get()->PushSync([reduce, result, this](RunContext rctx) {
           NDArray out = result;
+          Resource rsc = ResourceManager::Get()->Request(rctx.ctx,
+              ResourceRequest(ResourceRequest::kTempSpace));
           is_serial_push_?
             ReduceSumCPUExSerial(reduce, &out)
-            : mxnet::ndarray::ElementwiseSum(rctx.get_stream<cpu>(), reduce, &out);
+            : mxnet::ndarray::ElementwiseSum(rctx.get_stream<cpu>(), rsc, reduce, &out);
         }, Context::CPU(), const_vars, {result.var()},
         FnProperty::kCPUPrioritized, priority, PROFILER_MESSAGE("KVStoreReduce"));
     }

--- a/src/ndarray/ndarray_function-inl.cuh
+++ b/src/ndarray/ndarray_function-inl.cuh
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file ndarray_function-inl.cuh
+ * \brief Implementation of ndarray function kernels on GPU
+ */
+#ifndef MXNET_NDARRAY_NDARRAY_FUNCTION_INL_CUH_
+#define MXNET_NDARRAY_NDARRAY_FUNCTION_INL_CUH_
+
+namespace mxnet {
+namespace ndarray {
+
+/*!
+ * \brief GPU kernel to perform RSP tensor addition: out += in
+ * Parallelization by non-zero input elements: 1 thread/element
+ */
+struct ElementWiseRspAdditionKernel {
+  /*!
+   * \brief
+   * \param tid         global thread id
+   * \param data_out    rsp output data
+   * \param row_flg     rsp output inclusive prefix sum array over non-zero marked rows
+   * \param row_idx_in  rsp input non-zero row indices
+   * \param data_in     rsp input data
+   * \param nnr_in      rsp input number of non-zero rows
+   * \param row_length  rsp input and output number of elements per row
+   */
+  template<typename DType, typename IType>
+  __device__ __forceinline__ static void Map(int tid,
+                                             DType* data_out,
+                                             const IType* row_flg,
+                                             const IType* row_idx_in,
+                                             const DType* data_in,
+                                             const nnvm::dim_t nnr_in,
+                                             const nnvm::dim_t row_length) {
+    using nnvm::dim_t;
+    if (tid < nnr_in * row_length) {
+      dim_t in_row = tid / row_length;
+      dim_t in_col = tid % row_length;
+      dim_t out_row = row_flg[row_idx_in[in_row]] - 1;
+      dim_t out_idx = out_row * row_length + in_col;
+      data_out[out_idx] += data_in[tid];
+    }
+  }
+};
+
+}  // namespace ndarray
+}  // namespace mxnet
+
+#endif  // MXNET_NDARRAY_NDARRAY_FUNCTION_INL_CUH_

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -18,7 +18,7 @@
  */
 
 /*!
- * \file ndarray_function_cpu.cc
+ * \file ndarray_function.cc
  * \brief CPU Implementation of ndarray function.
  */
 
@@ -142,7 +142,9 @@ void GetUniqueRspRowIdx(const std::vector<NDArray>& nds,
   uniq_row_idx->resize(it - uniq_row_idx->begin());
 }
 
-void ElementwiseSumRsp(mshadow::Stream<cpu>* s, const std::vector<NDArray>& nds, NDArray* out) {
+void ElementwiseSumRsp(mshadow::Stream<cpu>* s,
+                       const std::vector<NDArray>& nds,
+                       NDArray* out) {
   if (nds.empty()) return;
   using namespace rowsparse;
   CHECK_EQ(out->storage_type(), kRowSparseStorage)
@@ -169,7 +171,6 @@ void ElementwiseSum<cpu>(mshadow::Stream<cpu>* s,
                          const std::vector<NDArray>& nds,
                          NDArray* out) {
   if (nds.empty()) return;
-
   if (nds[0].storage_type() == kRowSparseStorage) {
     ElementwiseSumRsp(s, nds, out);
   } else {

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -143,6 +143,7 @@ void GetUniqueRspRowIdx(const std::vector<NDArray>& nds,
 }
 
 void ElementwiseSumRsp(mshadow::Stream<cpu>* s,
+                       Resource rsc,
                        const std::vector<NDArray>& nds,
                        NDArray* out) {
   if (nds.empty()) return;
@@ -168,11 +169,12 @@ void ElementwiseSumRsp(mshadow::Stream<cpu>* s,
  */
 template<>
 void ElementwiseSum<cpu>(mshadow::Stream<cpu>* s,
+                         Resource rsc,
                          const std::vector<NDArray>& nds,
                          NDArray* out) {
   if (nds.empty()) return;
   if (nds[0].storage_type() == kRowSparseStorage) {
-    ElementwiseSumRsp(s, nds, out);
+    ElementwiseSumRsp(s, rsc, nds, out);
   } else {
     LOG(FATAL) << "ElementwiseSum<cpu> has not been implemented for storage_type = << "
                << nds[0].storage_type();

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -143,7 +143,7 @@ void GetUniqueRspRowIdx(const std::vector<NDArray>& nds,
 }
 
 void ElementwiseSumRsp(mshadow::Stream<cpu>* s,
-                       Resource rsc,
+                       const Resource& rsc,
                        const std::vector<NDArray>& nds,
                        NDArray* out) {
   if (nds.empty()) return;
@@ -154,6 +154,8 @@ void ElementwiseSumRsp(mshadow::Stream<cpu>* s,
 
   MSHADOW_TYPE_SWITCH(out->dtype(), DType, {
     MSHADOW_IDX_TYPE_SWITCH(out->aux_type(kIdx), IType, {
+      // TODO(Jun): Use resource rsc for temporary vector instead of
+      //            allocating it directly in GetUniqueRspRowIdx
       std::vector<IType> uniq_row_idx;
       GetUniqueRspRowIdx(nds, &uniq_row_idx);
       out->CheckAndAlloc({mshadow::Shape1(uniq_row_idx.size())});
@@ -169,7 +171,7 @@ void ElementwiseSumRsp(mshadow::Stream<cpu>* s,
  */
 template<>
 void ElementwiseSum<cpu>(mshadow::Stream<cpu>* s,
-                         Resource rsc,
+                         const Resource& rsc,
                          const std::vector<NDArray>& nds,
                          NDArray* out) {
   if (nds.empty()) return;

--- a/src/ndarray/ndarray_function.cu
+++ b/src/ndarray/ndarray_function.cu
@@ -18,14 +18,20 @@
  */
 
 /*!
- * \file ndarray_function_cpu.cc
+ * \file ndarray_function.cu
  * \brief GPU Implementation of ndarray function.
  */
 
 // this will be invoked by nvcc and compile GPU version
+#include <cub/cub.cuh>
 #include <dmlc/logging.h>
+#include "../operator/mxnet_op.h"
+#include "../operator/tensor/init_op.h"
+#include "../operator/tensor/util/tensor_util-inl.cuh"
+#include "../common/cuda_utils.h"
 #include "./ndarray_function.h"
 #include "./ndarray_function-inl.h"
+#include "./ndarray_function-inl.cuh"
 
 namespace mxnet {
 namespace ndarray {
@@ -88,5 +94,110 @@ void Copy<gpu, gpu>(const TBlob &from, TBlob *to,
                         s->stream_);
   }
 }
+
+/*!
+ * \brief GPU impl of elemwise sum for rowsparse tensors.
+ */
+void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
+                       const std::vector<NDArray>& nds,
+                       NDArray* out) {
+  using namespace mxnet::op;
+  using namespace rowsparse;
+  using nnvm::dim_t;
+  CHECK_EQ(out->storage_type(), kRowSparseStorage)
+    << "Expected rowsparse storage_type (" << out->storage_type() << " given)";
+  int init = 0;
+  for (const auto& nd : nds) {
+    if (nd.storage_initialized()) {
+      init++;
+    }
+  }
+  if (init == 0) {
+    FillZerosRspImpl<gpu>(s, out);
+    return;
+  }
+  const dim_t num_rows = out->shape()[0];
+  const dim_t row_length = out->shape().ProdShape(1, out->shape().ndim());
+  // TODO(stefan): use temporary workspace from OpContext instead of cudaMalloc
+  MSHADOW_TYPE_SWITCH(out->dtype(), DType, {  // data type
+    MSHADOW_IDX_TYPE_SWITCH(out->aux_type(kIdx), IType, {  // row_idx type
+      // Allocate temporary array row_flg
+      IType* row_flg = NULL;
+      CUDA_CALL(cudaMalloc(&row_flg, num_rows*sizeof(IType)));
+      dim_t num_threads = num_rows;
+      mxnet_op::Kernel<mxnet_op::set_zero, gpu>::Launch(s, num_threads, row_flg);
+      // Mark row_flg array with 1s for non-zero rows
+      for (const auto& nd : nds) {
+        if (nd.storage_initialized()) {
+          const IType* nd_row_idx = nd.aux_data(kIdx).dptr<IType>();
+          const dim_t nd_nnr = nd.storage_shape()[0];
+          num_threads = nd_nnr;
+          mxnet_op::Kernel<MarkRspRowFlgKernel, gpu>::Launch(s, num_threads,
+              row_flg, nd_row_idx, nd_nnr);
+        }
+      }
+      // Compute inclusive prefix sum over row_flg
+      void* d_temp_storage = NULL;
+      size_t temp_storage_bytes = 0;
+      cub::DeviceScan::InclusiveSum(d_temp_storage,
+                                    temp_storage_bytes,
+                                    row_flg,
+                                    row_flg,
+                                    num_rows,
+                                    mshadow::Stream<gpu>::GetStream(s));
+      CUDA_CALL(cudaMalloc(&d_temp_storage, temp_storage_bytes));
+      cub::DeviceScan::InclusiveSum(d_temp_storage,
+                                    temp_storage_bytes,
+                                    row_flg,
+                                    row_flg,
+                                    num_rows,
+                                    mshadow::Stream<gpu>::GetStream(s));
+      CUDA_CALL(cudaFree(d_temp_storage));
+      // Get total number of output non-zero rows from GPU and allocate out data and row_idx
+      dim_t nnr_out = 0;
+      CUDA_CALL(cudaMemcpy(&nnr_out, &row_flg[num_rows-1], sizeof(dim_t),
+                           cudaMemcpyDeviceToHost));
+      out->CheckAndAlloc({mshadow::Shape1(nnr_out)});
+      IType* out_row_idx = out->aux_data(kIdx).dptr<IType>();
+      DType* out_data = out->data().dptr<DType>();
+      // Fill row_idx array of output using row_flg
+      num_threads = num_rows;
+      mxnet_op::Kernel<FillRspRowIdxKernel, gpu>::Launch(s, num_threads,
+          out_row_idx, row_flg, num_rows);
+      // Perform elementwise addition, writing to output data
+      num_threads = nnr_out * row_length;
+      mxnet_op::Kernel<mxnet_op::set_zero, gpu>::Launch(s, num_threads, out_data);
+      for (const auto& nd : nds) {
+        if (nd.storage_initialized()) {
+          const IType* nd_row_idx = nd.aux_data(kIdx).dptr<IType>();
+          const DType* nd_data = nd.data().dptr<DType>();
+          const dim_t nd_nnr = nd.storage_shape()[0];
+          num_threads = nd_nnr * row_length;
+          mxnet_op::Kernel<ElementWiseRspAdditionKernel, gpu>::Launch(s, num_threads,
+              out_data, row_flg, nd_row_idx, nd_data, nd_nnr, row_length);
+        }
+      }
+      CUDA_CALL(cudaFree(row_flg));
+    });
+  });
+}
+
+/*!
+ * \brief Parallel gpu impl of elemwise sum for sparse tensors.
+ * Currently only support row sparse sum.
+ */
+template<>
+void ElementwiseSum<gpu>(mshadow::Stream<gpu>* s,
+                         const std::vector<NDArray>& nds,
+                         NDArray* out) {
+  if (nds.empty()) return;
+  if (nds[0].storage_type() == kRowSparseStorage) {
+    ElementwiseSumRspImpl(s, nds, out);
+  } else {
+    LOG(FATAL) << "ElementwiseSum<gpu> has not been implemented for storage_type = << "
+        << nds[0].storage_type();
+  }
+}
+
 }  // namespace ndarray
 }  // namespace mxnet

--- a/src/ndarray/ndarray_function.cu
+++ b/src/ndarray/ndarray_function.cu
@@ -99,8 +99,9 @@ void Copy<gpu, gpu>(const TBlob &from, TBlob *to,
  * \brief GPU impl of elemwise sum for rowsparse tensors.
  */
 void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
-                       const std::vector<NDArray>& nds,
-                       NDArray* out) {
+                           Resource rsc,
+                           const std::vector<NDArray>& nds,
+                           NDArray* out) {
   using namespace mxnet::op;
   using namespace rowsparse;
   using nnvm::dim_t;
@@ -110,6 +111,7 @@ void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
   for (const auto& nd : nds) {
     if (nd.storage_initialized()) {
       init++;
+      break;
     }
   }
   if (init == 0) {
@@ -188,11 +190,12 @@ void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
  */
 template<>
 void ElementwiseSum<gpu>(mshadow::Stream<gpu>* s,
+                         Resource rsc,
                          const std::vector<NDArray>& nds,
                          NDArray* out) {
   if (nds.empty()) return;
   if (nds[0].storage_type() == kRowSparseStorage) {
-    ElementwiseSumRspImpl(s, nds, out);
+    ElementwiseSumRspImpl(s, rsc, nds, out);
   } else {
     LOG(FATAL) << "ElementwiseSum<gpu> has not been implemented for storage_type = << "
         << nds[0].storage_type();

--- a/src/ndarray/ndarray_function.cu
+++ b/src/ndarray/ndarray_function.cu
@@ -99,7 +99,7 @@ void Copy<gpu, gpu>(const TBlob &from, TBlob *to,
  * \brief GPU impl of elemwise sum for rowsparse tensors.
  */
 void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
-                           Resource rsc,
+                           const Resource& rsc,
                            const std::vector<NDArray>& nds,
                            NDArray* out) {
   using namespace mxnet::op;
@@ -120,7 +120,6 @@ void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
   }
   const dim_t num_rows = out->shape()[0];
   const dim_t row_length = out->shape().ProdShape(1, out->shape().ndim());
-  // TODO(stefan): use temporary workspace from OpContext instead of cudaMalloc
   MSHADOW_TYPE_SWITCH(out->dtype(), DType, {  // data type
     MSHADOW_IDX_TYPE_SWITCH(out->aux_type(kIdx), IType, {  // row_idx type
       // Allocate temporary storage for row_flg array and cub's prefix sum operation
@@ -191,7 +190,7 @@ void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
  */
 template<>
 void ElementwiseSum<gpu>(mshadow::Stream<gpu>* s,
-                         Resource rsc,
+                         const Resource& rsc,
                          const std::vector<NDArray>& nds,
                          NDArray* out) {
   if (nds.empty()) return;

--- a/src/ndarray/ndarray_function.h
+++ b/src/ndarray/ndarray_function.h
@@ -174,7 +174,7 @@ void ElementwiseSum(const std::vector<TBlob> source,
  */
 template<typename xpu>
 void ElementwiseSum(mshadow::Stream<xpu>* s,
-                    Resource rsc,
+                    const Resource& rsc,
                     const std::vector<NDArray>& nds,
                     NDArray* out);
 

--- a/src/ndarray/ndarray_function.h
+++ b/src/ndarray/ndarray_function.h
@@ -174,6 +174,7 @@ void ElementwiseSum(const std::vector<TBlob> source,
  */
 template<typename xpu>
 void ElementwiseSum(mshadow::Stream<xpu>* s,
+                    Resource rsc,
                     const std::vector<NDArray>& nds,
                     NDArray* out);
 

--- a/src/operator/tensor/dot-inl.cuh
+++ b/src/operator/tensor/dot-inl.cuh
@@ -46,7 +46,7 @@ struct DotCsrDnsDnsScalarKernel {
    * \param data_l      csr matrix data
    * \param indptr_l    csr matrix row index pointer
    * \param col_idx_l   csr matrix column indices
-   * \param data_r      dns1 matrix data of rhs
+   * \param data_r      dns1 matrix data
    * \param num_cols_r  dns1 matrix number of columns
    */
   template<typename DType, typename IType, typename CType>
@@ -861,7 +861,7 @@ inline void DotCsrRspDnsImpl(const OpContext& ctx,
             Kernel<set_zero, gpu>::Launch(s, num_threads, row_flg_r);
             // Set row_flg index array
             num_threads = nnr_r;
-            Kernel<SetRspRowFlgKernel, gpu>::Launch(s, num_threads,
+            Kernel<IndexRspRowFlgKernel, gpu>::Launch(s, num_threads,
                 row_flg_r, row_idx_r.dptr<RType>(), nnr_r);
             // Perform sparse matrix-matrix multiply
             num_threads = num_rows*num_cols;

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -91,10 +91,9 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(req.size(), 1U);
   if (req[0] == kNullOp) return;
   CHECK_EQ(req[0], kWriteTo) << "ElementWiseSumComputeExCPU only supports req = kWriteTo";
-  using namespace mshadow;
-  Stream<cpu>* s = ctx.get_stream<cpu>();
-  NDArray out_nd = outputs[0];
   if (inputs[0].storage_type() == kRowSparseStorage) {
+    mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
+    NDArray out_nd = outputs[0];
     mxnet::ndarray::ElementwiseSum<cpu>(s, inputs, &out_nd);
   } else {
     FCompExFallback<cpu>(attrs, ctx, inputs, req, outputs,

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -82,7 +82,7 @@ bool ElementWiseSumForwardInferStorageType(const nnvm::NodeAttrs& attrs,
 }
 
 void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
-                                const OpContext& ctx,
+                                const OpContext& op_ctx,
                                 const std::vector<NDArray>& inputs,
                                 const std::vector<OpReqType>& req,
                                 const std::vector<NDArray>& outputs) {
@@ -92,11 +92,13 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
   if (req[0] == kNullOp) return;
   CHECK_EQ(req[0], kWriteTo) << "ElementWiseSumComputeExCPU only supports req = kWriteTo";
   if (inputs[0].storage_type() == kRowSparseStorage) {
-    mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
+    mshadow::Stream<cpu>* s = op_ctx.get_stream<cpu>();
+    Resource rsc = ResourceManager::Get()->Request(op_ctx.run_ctx.get_ctx(),
+        ResourceRequest(ResourceRequest::kTempSpace));
     NDArray out_nd = outputs[0];
-    mxnet::ndarray::ElementwiseSum<cpu>(s, inputs, &out_nd);
+    mxnet::ndarray::ElementwiseSum<cpu>(s, rsc, inputs, &out_nd);
   } else {
-    FCompExFallback<cpu>(attrs, ctx, inputs, req, outputs,
+    FCompExFallback<cpu>(attrs, op_ctx, inputs, req, outputs,
                          ElementWiseSumCompute<cpu>, "ElementWiseSumCompute<cpu>");
   }
 }
@@ -137,6 +139,10 @@ The storage type of ``add_n`` output depends on storage types of inputs
     "FInplaceOption", [](const NodeAttrs& attrs) {
       return std::vector<std::pair<int, int> >{{0, 0}};
     })
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+  })
 .set_attr<nnvm::FInferShape>("FInferShape", ElementWiseSumShape)
 .set_attr<nnvm::FInferType>("FInferType", ElementWiseSumType)
 .set_attr<FInferStorageType>("FInferStorageType", ElementWiseSumForwardInferStorageType)

--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -44,11 +44,9 @@ void ElementWiseSumComputeExGPU(const nnvm::NodeAttrs& attrs,
     NDArray out_nd = outputs[0];
     mxnet::ndarray::ElementwiseSum<gpu>(s, rsc, inputs, &out_nd);
   } else {
-    // TODO(stefan): add fallback
-    LOG(FATAL) << "TODO: fallback";
-    //FCompExFallback<gpu>(attrs, op_ctx, inputs, req, outputs,
-    //                     ElementWiseSumComputeWithHalf2<gpu>,
-    //                     "ElementWiseSumComputeWithHalf2<gpu>");
+    FCompExFallback<gpu>(attrs, op_ctx, inputs, req, outputs,
+                         ElementWiseSumComputeWithHalf2<gpu>,
+                         "ElementWiseSumComputeWithHalf2<gpu>");
   }
 }
 

--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -26,8 +26,31 @@
 namespace mxnet {
 namespace op {
 
+void ElementWiseSumComputeExGPU(const nnvm::NodeAttrs& attrs,
+                                const OpContext& ctx,
+                                const std::vector<NDArray>& inputs,
+                                const std::vector<OpReqType>& req,
+                                const std::vector<NDArray>& outputs) {
+  CHECK(!inputs.empty());
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  if (req[0] == kNullOp) return;
+  CHECK_EQ(req[0], kWriteTo) << "ElementWiseSumComputeExGPU only supports req = kWriteTo";
+  if (inputs[0].storage_type() == kRowSparseStorage) {
+    NDArray out_nd = outputs[0];
+    mxnet::ndarray::ElementwiseSum<gpu>(ctx.get_stream<gpu>(), inputs, &out_nd);
+  } else {
+    // TODO(stefan): add fallback
+    LOG(FATAL) << "TODO: fallback";
+    //FCompExFallback<gpu>(attrs, ctx, inputs, req, outputs,
+    //                     ElementWiseSumComputeWithHalf2<gpu>,
+    //                     "ElementWiseSumComputeWithHalf2<gpu>");
+  }
+}
+
 NNVM_REGISTER_OP(add_n)
-.set_attr<FCompute>("FCompute<gpu>", ElementWiseSumComputeWithHalf2<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", ElementWiseSumComputeWithHalf2<gpu>)
+.set_attr<FComputeEx>("FComputeEx<gpu>", ElementWiseSumComputeExGPU);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/util/tensor_util-inl.cuh
+++ b/src/operator/tensor/util/tensor_util-inl.cuh
@@ -149,16 +149,39 @@ struct MarkRspRowBlockKernel {
 };
 
 /*!
- * \brief GPU kernel to flag non-zero rows of an rsp tensor with indices.
- * Parallelized by matrix rows: 1 thread/row
+ * \brief GPU kernel to flag non-zero rows of an rsp tensor with 1.
+ * Parallelized by tensor rows: 1 thread/row
  */
-struct SetRspRowFlgKernel {
+struct MarkRspRowFlgKernel {
   /*!
    * \brief
    * \param tid      global thread id
    * \param row_flg  array to flag storage indices of non-zero rows
-   * \param row_idx  rsp matrix row index array storing indices of non-zero rows
-   * \param nnr      rsp matrix number of non-zero rows (storage shape)
+   * \param row_idx  rsp tensor row index array storing indices of non-zero rows
+   * \param nnr      rsp tensor number of non-zero rows (storage shape)
+   */
+  template<typename IType>
+  __device__ __forceinline__ static void Map(int tid,
+                                             IType* row_flg,
+                                             const IType* row_idx,
+                                             const nnvm::dim_t nnr) {
+    if (tid < nnr) {
+      row_flg[row_idx[tid]] = 1;
+    }
+  }
+};
+
+/*!
+ * \brief GPU kernel to flag non-zero rows of an rsp tensor with indices.
+ * Parallelized by matrix rows: 1 thread/row
+ */
+struct IndexRspRowFlgKernel {
+  /*!
+   * \brief
+   * \param tid      global thread id
+   * \param row_flg  array to flag storage indices of non-zero rows
+   * \param row_idx  rsp tensor row index array storing indices of non-zero rows
+   * \param nnr      rsp tensor number of non-zero rows (storage shape)
    */
   template<typename RType>
   __device__ __forceinline__ static void Map(int tid,

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -33,6 +33,7 @@ from test_gluon import *
 from test_gluon_rnn import *
 from test_sparse_operator import test_cast_storage_ex, test_sparse_dot
 from test_sparse_operator import test_sparse_nd_zeros, test_sparse_retain
+from test_sparse_operator import test_sparse_elementwise_sum
 from test_sparse_ndarray import test_create_csr, test_create_row_sparse
 
 set_default_context(mx.gpu(0))

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -342,7 +342,7 @@ def test_sparse_elementwise_sum():
         out = mx.symbol.add_n(*inputs, name='esum')
         arr = []
         arr_grad = [mx.nd.empty(shape) for _ in range(n)]
-        densities = [0, 0.01, 0.1, 0.2, 0.3, 0.4, 0.5]
+        densities = [0, 0.01, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0]
         for i in range(n):
             arr.append(rand_ndarray(shape, stype, densities[np.random.randint(0, len(densities))]))
 

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -344,7 +344,7 @@ def test_sparse_elementwise_sum():
         arr_grad = [mx.nd.empty(shape) for _ in range(n)]
         densities = [0, 0.01, 0.1, 0.2, 0.3, 0.4, 0.5]
         for i in range(n):
-            arr.append(rand_ndarray(shape, stype, np.random.randint(0, len(densities))))
+            arr.append(rand_ndarray(shape, stype, densities[np.random.randint(0, len(densities))]))
 
         exec1 = out.bind(default_context(),
                          args=arr,
@@ -363,8 +363,9 @@ def test_sparse_elementwise_sum():
 
     maxdim = 5
     for dim in range(2, maxdim):
-        shape = tuple(np.random.randint(5, 10, size=dim))
-        check_sparse_elementwise_sum_with_shape('row_sparse', shape, np.random.randint(1, 9))
+        for i in range(3):
+            shape = tuple(np.random.randint(5, 10, size=dim))
+            check_sparse_elementwise_sum_with_shape('row_sparse', shape, np.random.randint(1, 9))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@madjam @reminisce @eric-haibin-lin @anirudh2290 @cjolivier01 @bhavinthaker

Future work, not in scope of this PR:
- benchmarks for elemwise sum operator
- consider a second, different GPU implementation that performs better on certain cases (see explanation below)

Algorithm outline:
  1. Initialize an array for row flags to mark non-zero rows of input tensors, in parallel.
  2. Compute an inclusive parallel prefix sum over row_flg.
  3. The last entry of row_flg (total non-zero rows) is used to allocate output tensor.
     Then, use row_flg to set the non-zero indices in row_idx, in parallel.
  4. Finally, compute output data by iterating over the input tensors, each one is added in parallel.
done.

This algorithm has high parallelism thanks to the use of the row_flg array. I expect the implementation to perform well except in cases where the input tensors are extremely sparse. Then, allocating and computing the prefix sum over the row_flg array may add unjustifiably high computational and memory op costs. Thus whenever the size of the row_flg array (shape[0]) seems too high relative to the computed data, another kernel with less parallelism may be the better option. See, for example, the CPU implementation. To test and optimize, we'll need benchmarks for this operator.