### PR TITLE
avoid cast_storage in dist-kvstore-server

### DIFF
--- a/src/kvstore/kvstore_dist_server.h
+++ b/src/kvstore/kvstore_dist_server.h
@@ -235,7 +235,8 @@ class KVStoreDistServer {
             stored.CheckAndAlloc({mshadow::Shape1(recved.shape()[0])});
             mshadow::Stream<cpu> *s = ctx.get_stream<cpu>();
             op::PopulateFullIdxRspImpl(s, &rsp);
-            mshadow::Copy(recved.data().FlatTo1D<cpu, float>(), rsp.data().FlatTo1D<cpu, float>());
+            mshadow::Copy(recved.data().FlatTo1D<cpu, float>(),
+                          rsp.data().FlatTo1D<cpu, float>(), s);
           }, recved.ctx(), {recved.var()}, {stored.var()},
           FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
         stored.WaitToRead();

--- a/src/kvstore/kvstore_dist_server.h
+++ b/src/kvstore/kvstore_dist_server.h
@@ -34,6 +34,7 @@
 #include "ps/ps.h"
 #include "mxnet/kvstore.h"
 #include "../operator/tensor/elemwise_binary_op.h"
+#include "../operator/tensor/init_op.h"
 
 namespace mxnet {
 namespace kvstore {
@@ -228,11 +229,15 @@ class KVStoreDistServer {
         CHECK_EQ(req_data.vals.size(), num_rows * unit_len);
         TBlob recv_blob(data, dshape, cpu::kDevMask);  // NOLINT(*)
         NDArray recved = NDArray(recv_blob, 0);
-        // TODO(haibin) temporarily initialized as dense NDArray. We need inplace operator
-        // support for rowsparse ndarrays. And after that `stored` should be initialized as
-        // RowSparse NDArray
         stored = NDArray(kRowSparseStorage, dshape, Context());
-        CopyFromTo(recved, &stored, 0);
+        Engine::Get()->PushSync([recved, stored](RunContext ctx) {
+            NDArray rsp = stored;
+            stored.CheckAndAlloc({mshadow::Shape1(recved.shape()[0])});
+            mshadow::Stream<cpu> *s = ctx.get_stream<cpu>();
+            op::PopulateFullIdxRspImpl(s, &rsp);
+            mshadow::Copy(recved.data().FlatTo1D<cpu, float>(), rsp.data().FlatTo1D<cpu, float>());
+          }, recved.ctx(), {recved.var()}, {stored.var()},
+          FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
         stored.WaitToRead();
         server->Response(req_meta);
         return;

--- a/src/kvstore/kvstore_dist_server.h
+++ b/src/kvstore/kvstore_dist_server.h
@@ -235,8 +235,8 @@ class KVStoreDistServer {
             stored.CheckAndAlloc({mshadow::Shape1(recved.shape()[0])});
             mshadow::Stream<cpu> *s = ctx.get_stream<cpu>();
             op::PopulateFullIdxRspImpl(s, &rsp);
-            mshadow::Copy(recved.data().FlatTo1D<cpu, float>(),
-                          rsp.data().FlatTo1D<cpu, float>(), s);
+            mshadow::Copy(rsp.data().FlatTo1D<cpu, float>(),
+                          recved.data().FlatTo1D<cpu, float>(), s);
           }, recved.ctx(), {recved.var()}, {stored.var()},
           FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
         stored.WaitToRead();


### PR DESCRIPTION
sparse optimizers such as SGD expects weight.indices contains all indices from [0, feature_dim). Currently the initialization function at dist_kvstore_server converts a dense NDArray into a RowSparse one during `CopyFromTo`. This will lead to missing row indices during the conversion since row slices of all zeros are remove in result. 
@reminisce @anirudh2290 @cjolivier01 